### PR TITLE
docs: add 8 source-backed OpenClaw use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 - 部署与配置：Mac、Windows、Linux VPS、多 Agent
 - 渠道接入：飞书、钉钉、企业微信、QQ（持续补充）
-- 使用场景：176 个真实案例与工作流
+- 使用场景：184 个真实案例与工作流
 
 ## 开始使用 OpenClaw
 
@@ -21,7 +21,7 @@
 
 1. [部署后 5 分钟快速体验](./quickstart/00-5min-quickstart.md)
 2. [7 天上手路径](./quickstart/01-7day-path.md)
-3. [按分类找案例（176个）](./resources/usecases-index.md)
+3. [按分类找案例（184个）](./resources/usecases-index.md)
 
 ### 推荐部署入口
 
@@ -51,20 +51,20 @@
 
 ## 分类导航
 
-- [全量用例索引（176）](./resources/usecases-index.md)
-- [社交媒体（6）](./usecases/social)
+- [全量用例索引（184）](./resources/usecases-index.md)
+- [社交媒体（7）](./usecases/social)
 - [创意与构建（8）](./usecases/creative)
-- [基础设施与 DevOps（11）](./usecases/devops)
-- [生产力（28）](./usecases/productivity)
-- [研究与学习（10）](./usecases/research)
+- [基础设施与 DevOps（12）](./usecases/devops)
+- [生产力（30）](./usecases/productivity)
+- [研究与学习（12）](./usecases/research)
 - [金融与交易（1）](./usecases/finance)
 - [日常生活（33）](./usecases/everyday)
-- [内容转换（14）](./usecases/content)
+- [内容转换（15）](./usecases/content)
 - [内存管理（11）](./usecases/memory)
 - [夜间自动化（15）](./usecases/automation)
 - [数据分析（16）](./usecases/data)
 - [安全监控（16）](./usecases/security)
-- [工具开发（7）](./usecases/tools)
+- [工具开发（8）](./usecases/tools)
 
 ## 部署与运行建议
 

--- a/resources/usecases-index.json
+++ b/resources/usecases-index.json
@@ -1582,5 +1582,77 @@
     "sourceRepo": "openclaw.ai/showcase",
     "sourcePath": "x.com/tonylongname/status/2008970037013381165",
     "sourceUrl": "https://x.com/tonylongname/status/2008970037013381165"
+  },
+  {
+    "title": "一个 OpenClaw 管多个飞书机器人",
+    "desc": "用多账号、多 Agent、可选多 Gateway 的方式，把不同飞书机器人稳定路由到不同 OpenClaw 身份。",
+    "category": "生产力",
+    "localPath": "usecases/productivity/11-multi-gateway-feishu-bots.md",
+    "sourceRepo": "openclaw/openclaw",
+    "sourcePath": "docs/concepts/multi-agent.md",
+    "sourceUrl": "https://github.com/openclaw/openclaw/blob/main/docs/concepts/multi-agent.md"
+  },
+  {
+    "title": "OpenClaw 调度 Claude Code 与 Codex CLI",
+    "desc": "让 OpenClaw 作为总控，把 Claude Code、Codex CLI 这类 coding harness 接进同一套工作流。",
+    "category": "工具开发",
+    "localPath": "usecases/tools/51-openclaw-claude-code-codex-cli.md",
+    "sourceRepo": "openclaw/openclaw",
+    "sourcePath": "docs/tools/acp-agents.md",
+    "sourceUrl": "https://github.com/openclaw/openclaw/blob/main/docs/tools/acp-agents.md"
+  },
+  {
+    "title": "HF Papers 研究发现流水线",
+    "desc": "每天自动抓 Hugging Face Papers 热门论文，再联动 arXiv 深读，形成一套持续研究雷达。",
+    "category": "研究与学习",
+    "localPath": "usecases/research/21-hf-papers-research-discovery.md",
+    "sourceRepo": "hesamsheikh/awesome-openclaw-usecases",
+    "sourcePath": "usecases/hf-papers-research-discovery.md",
+    "sourceUrl": "https://github.com/hesamsheikh/awesome-openclaw-usecases/blob/main/usecases/hf-papers-research-discovery.md"
+  },
+  {
+    "title": "AI 视频编辑助手",
+    "desc": "用聊天方式完成粗剪、加字幕、转竖屏和批量导出，把重复视频后处理交给 OpenClaw。",
+    "category": "内容转换",
+    "localPath": "usecases/content/48-ai-video-editing-assistant.md",
+    "sourceRepo": "hesamsheikh/awesome-openclaw-usecases",
+    "sourcePath": "usecases/ai-video-editing.md",
+    "sourceUrl": "https://github.com/hesamsheikh/awesome-openclaw-usecases/blob/main/usecases/ai-video-editing.md"
+  },
+  {
+    "title": "X / Twitter 自动化运营",
+    "desc": "用 OpenClaw 统一完成发帖、回复、监控、抽奖和数据抽取，把 X/Twitter 运营动作收回到聊天里。",
+    "category": "社交媒体",
+    "localPath": "usecases/social/07-x-twitter-automation-ops.md",
+    "sourceRepo": "Xquik-dev/tweetclaw",
+    "sourcePath": "README.md",
+    "sourceUrl": "https://github.com/Xquik-dev/tweetclaw/blob/main/README.md"
+  },
+  {
+    "title": "arXiv 论文阅读助手",
+    "desc": "直接按 arXiv ID 抓摘要、目录和全文，让 OpenClaw 变成可对话的论文阅读器。",
+    "category": "研究与学习",
+    "localPath": "usecases/research/22-arxiv-paper-reader.md",
+    "sourceRepo": "Prismer-AI/Prismer",
+    "sourcePath": "skills/arxiv-reader/SKILL.md",
+    "sourceUrl": "https://github.com/Prismer-AI/Prismer/blob/main/skills/arxiv-reader/SKILL.md"
+  },
+  {
+    "title": "本地 CRM / DenchClaw 框架",
+    "desc": "用 DenchClaw 把 OpenClaw 变成一套本地优先的 CRM、销售自动化和业务运营工作台。",
+    "category": "生产力",
+    "localPath": "usecases/productivity/12-denchclaw-local-crm-framework.md",
+    "sourceRepo": "DenchHQ/DenchClaw",
+    "sourcePath": "README.md",
+    "sourceUrl": "https://github.com/DenchHQ/DenchClaw/blob/main/README.md"
+  },
+  {
+    "title": "Claworc 多实例控制台",
+    "desc": "用一个 Web 控制台集中管理多个 OpenClaw 实例，把实例隔离、权限控制和运维入口统一起来。",
+    "category": "基础设施与 DevOps",
+    "localPath": "usecases/devops/21-claworc-multi-instance-control-plane.md",
+    "sourceRepo": "gluk-w/claworc",
+    "sourcePath": "README.md",
+    "sourceUrl": "https://github.com/gluk-w/claworc/blob/main/README.md"
   }
 ]

--- a/resources/usecases-index.md
+++ b/resources/usecases-index.md
@@ -1,10 +1,10 @@
 # 用例总览
 
-当前共收录 **176** 个中文可用案例。
+当前共收录 **184** 个中文可用案例。
 
 按分类浏览：
 
-## 社交媒体 (6)
+## 社交媒体 (7)
 
 | 用例 | 能干什么 |
 |---|---|
@@ -14,6 +14,7 @@
 | [每日AI行业日报推送](../usecases/social/daily-ai-news-report-push.md) | 每天定时推送 AI 行业动态，快速掌握最新趋势。 |
 | [每周技术发现精选](../usecases/social/tech-discoveries-showcase.md) | 自动追踪和筛选技术动态，输出可读性高的周报。 |
 | [X 账号分析](../usecases/social/x-account-analysis.md) | 获取你的 X 账号的定性分析。 |
+| [X / Twitter 自动化运营](../usecases/social/07-x-twitter-automation-ops.md) | 用 OpenClaw 统一完成发帖、回复、监控、抽奖和数据抽取，把 X/Twitter 运营动作收回到聊天里。 |
 
 ## 创意与构建 (8)
 
@@ -24,11 +25,11 @@
 | [目标驱动的自主任务](../usecases/creative/overnight-mini-app-builder.md) | 倾泻你的目标，让智能体自主生成、安排并完成每日任务 —— 包括在一夜之间构建惊喜的迷你应用。 |
 | [视频脚本生成工作流](../usecases/creative/video-script-generator-workflow.md) | 短视频与长视频脚本自动生成，支持系列化输出。 |
 | [AI绘画生产工作流](../usecases/creative/ai-image-generation-workflow.md) | 从想法到配图的批量化创作流程，适合内容团队。 |
-| [Excalidraw Diagram-as-Code（流程图自动生成）](../usecases/creative/02-excalidraw-diagram-as-code.md) | 让 OpenClaw 直接生成 Excalidraw JSON，把文本需求快速转成流程图。 |
 | [YouTube 内容流水线](../usecases/creative/youtube-content-pipeline.md) | 为 YouTube 频道自动化视频创意发掘、研究和追踪。 |
+| [Excalidraw Diagram-as-Code（流程图自动生成）](../usecases/creative/02-excalidraw-diagram-as-code.md) | 让 OpenClaw 直接生成 Excalidraw JSON，把文本需求快速转成流程图。 |
 | [WhatsApp 驱动 UI 生成与截图回传](../usecases/creative/whatsapp-driven-ui-with-screenshot-feedback.md) | 通过 WhatsApp 远程生成界面并回传截图，先看效果再继续迭代。 |
 
-## 基础设施与 DevOps (11)
+## 基础设施与 DevOps (12)
 
 | 用例 | 能干什么 |
 |---|---|
@@ -36,15 +37,16 @@
 | [家庭实验室远程安全访问](../usecases/devops/homelab-access-showcase.md) | 通过聊天工具安全触发远程运维操作，降低误操作风险。 |
 | [自愈家庭服务器](../usecases/devops/self-healing-home-server.md) | 运行一个始终在线的基础设施智能体，具有 SSH 访问权限、自动化 cron 作业，以及跨家庭网络的自愈能力。 |
 | [AI编程协作模式](../usecases/devops/ai-coding-collaboration.md) | 把编码、测试、修复流程交给AI协作完成。 |
-| [自主教育游戏开发流水线（Autonomous Educational Game Development Pipeline）](../usecases/devops/autonomous-game-dev-pipeline.md) | 以“先修 Bug、再做新游戏”规则持续推进教育游戏开发。 |
-| [用户流测试 → 并行 PR 修复流水线](../usecases/devops/04-user-flow-to-pr-parallel-fix.md) | 把用户流测试问题结构化后并行派发修复，提升回归效率。 |
+| [n8n 工作流编排](../usecases/devops/n8n-workflow-orchestration.md) | 通过 webhook 将 API 调用委托给 n8n 工作流 —— 智能体从不接触凭证，每个集成都是可视化的且可锁定。 |
+| [VPS部署与加固流程](../usecases/devops/vps-deployment-hardening.md) | 从部署到安全收口的一体化流程，适合长期在线运行。 |
+| [用户流测试 → 并行 PR 修复流水线](../usecases/devops/04-user-flow-to-pr-parallel-fix.md) | 将测试问题结构化后并行派发修复，缩短回归周期。 |
 | [语音驱动 Railway 故障定位与修复](../usecases/devops/06-voice-driven-railway-incident-fix.md) | 在移动场景通过语音指令完成排障、修复、验证和复盘。 |
 | [Telegram 远程站点迁移（Notion → Astro + DNS）](../usecases/devops/07-telegram-notion-astro-migration.md) | 通过 Telegram 远程驱动内容迁移、静态站重建与 DNS 切换。 |
 | [Telegram 驱动 iOS 提交与 TestFlight 更新](../usecases/devops/19-telegram-driven-ios-testflight-release.md) | 在聊天中触发 iOS 发布流程并标准化 TestFlight 更新。 |
-| [n8n 工作流编排](../usecases/devops/n8n-workflow-orchestration.md) | 通过 webhook 将 API 调用委托给 n8n 工作流 —— 智能体从不接触凭证，每个集成都是可视化的且可锁定。 |
-| [VPS部署与加固流程](../usecases/devops/vps-deployment-hardening.md) | 从部署到安全收口的一体化流程，适合长期在线运行。 |
+| [自主教育游戏开发流水线（Autonomous Educational Game Development Pipeline）](../usecases/devops/autonomous-game-dev-pipeline.md) | 以先修 Bug 再做新游戏的规则持续推进教育游戏开发。 |
+| [Claworc 多实例控制台](../usecases/devops/21-claworc-multi-instance-control-plane.md) | 用一个 Web 控制台集中管理多个 OpenClaw 实例，把实例隔离、权限控制和运维入口统一起来。 |
 
-## 生产力 (28)
+## 生产力 (30)
 
 | 用例 | 能干什么 |
 |---|---|
@@ -53,7 +55,6 @@
 | [定制早间简报](../usecases/productivity/custom-morning-brief.md) | 获取完全定制的每日简报 —— 新闻、任务、内容草稿和 AI 推荐的操作 —— 每天早上通过短信发送给你。 |
 | [动态仪表板](../usecases/productivity/dynamic-dashboard.md) | 实时仪表板，并行从 API、数据库和社交媒体获取数据。 |
 | [多机器人多Agent矩阵](../usecases/productivity/multi-bot-multi-agent-matrix.md) | 多渠道机器人协同，按角色分工处理不同业务任务。 |
-| [跨 Bot 协作（同一 WhatsApp 群）](../usecases/productivity/10-cross-bot-whatsapp-collaboration.md) | 让两个 OpenClaw 在同一群里分工协作，处理复杂任务。 |
 | [多渠道 AI 客户服务](../usecases/productivity/multi-channel-customer-service.md) | 将 WhatsApp、Instagram、电子邮件和 Google 评价统一到一个 AI 驱动的收件箱中，实现 24/7 自动回复。 |
 | [多渠道个人助理](../usecases/productivity/multi-channel-assistant.md) | 从单个 AI 助理路由任务到 Telegram、Slack、电子邮件和日历。 |
 | [多智能体专业团队](../usecases/productivity/multi-agent-team.md) | 通过单个 Telegram 聊天，将多个专业智能体（战略、开发、营销、业务）作为协调团队运行。 |
@@ -67,7 +68,6 @@
 | [任务追踪透明化中心](../usecases/productivity/task-tracking-workflow-center.md) | 把智能体任务状态结构化记录，随时看到进展与阻塞。 |
 | [社区版每日简报（Daily Brief）](../usecases/productivity/daily-brief-showcase.md) | 每天自动汇总天气、日程、任务和重点信息，早上一次看完。 |
 | [收件箱整理](../usecases/productivity/inbox-declutter.md) | 总结新闻通讯并以电子邮件形式发送给你摘要。 |
-| [自动会议纪要与行动项分发（Automated Meeting Notes & Action Items）](../usecases/productivity/automated-meeting-notes-action-items.md) | 会后自动生成纪要并把行动项分发到任务系统。 |
 | [项目状态管理](../usecases/productivity/project-state-management.md) | 事件驱动的项目追踪，自动捕获上下文，取代静态看板。 |
 | [学生学习助手工作流](../usecases/productivity/student-learning-assistant-workflow.md) | 课程管理、复习规划、作业辅助的一体化学习流程。 |
 | [知识工作者全天工作流](../usecases/productivity/knowledge-worker-day-workflow.md) | 覆盖日报、资料、会议、复盘的一整天效率流程。 |
@@ -75,9 +75,13 @@
 | [自主项目管理](../usecases/productivity/autonomous-project-management.md) | 使用 STATE.yaml 模式协调多智能体项目 —— 子智能体并行工作，无需编排器开销。 |
 | [Notion全自动运营工作流](../usecases/productivity/notion-automatic-operation-flow.md) | 把内容与运营动作自动落到 Notion，减少手工维护。 |
 | [Todoist 任务管理器](../usecases/productivity/todoist-task-manager.md) | 通过将推理和进度日志同步到 Todoist，最大化智能体的透明度。 |
+| [跨 Bot 协作（同一 WhatsApp 群）](../usecases/productivity/10-cross-bot-whatsapp-collaboration.md) | 让两个 OpenClaw 在同一群里分工协作，处理复杂任务。 |
+| [自动会议纪要与行动项分发（Automated Meeting Notes & Action Items）](../usecases/productivity/automated-meeting-notes-action-items.md) | 会后自动生成纪要并把行动项分发到任务系统。 |
 | [任务时间块排程与周复盘助理](../usecases/productivity/task-timeblocking-and-weekly-review-assistant.md) | 按优先级排进日历，并基于会议转录输出 weekly review 和后续动作。 |
+| [一个 OpenClaw 管多个飞书机器人](../usecases/productivity/11-multi-gateway-feishu-bots.md) | 用多账号、多 Agent、可选多 Gateway 的方式，把不同飞书机器人稳定路由到不同 OpenClaw 身份。 |
+| [本地 CRM / DenchClaw 框架](../usecases/productivity/12-denchclaw-local-crm-framework.md) | 用 DenchClaw 把 OpenClaw 变成一套本地优先的 CRM、销售自动化和业务运营工作台。 |
 
-## 研究与学习 (10)
+## 研究与学习 (12)
 
 | 用例 | 能干什么 |
 |---|---|
@@ -88,9 +92,11 @@
 | [想法漏斗自动推进（Idea Pipeline）](../usecases/research/idea-pipeline-showcase.md) | 把零散想法自动收集、筛选、排序并推进到下一步执行。 |
 | [语义记忆搜索](../usecases/research/semantic-memory-search.md) | 使用混合检索和自动同步，为你的 OpenClaw markdown 记忆文件添加向量驱动的语义搜索。 |
 | [自托管知识库助手（Coeus）](../usecases/research/coeus-knowledge-base-showcase.md) | 把资料持续沉淀到可检索知识库，支持长期复用。 |
-| [想法 → 实验 → 决策（ADR）夜间闭环](../usecases/research/20-idea-experiment-adr-night-loop.md) | 白天收集想法、夜间自动实验、次日输出 ADR 决策记录。 |
-| [开工前想法验证闸门（Pre-Build Idea Validator）](../usecases/research/pre-build-idea-validator.md) | 开发前先做竞争度扫描，用 `reality_signal` 决定继续或转向。 |
 | [AI 财报追踪器](../usecases/research/earnings-tracker.md) | 追踪科技/AI 财报，带有自动化预览、警报和详细摘要。 |
+| [想法 → 实验 → 决策（ADR）夜间闭环](../usecases/research/20-idea-experiment-adr-night-loop.md) | 白天收集想法、夜间自动实验、次日输出 ADR 决策记录。 |
+| [开工前想法验证闸门（Pre-Build Idea Validator）](../usecases/research/pre-build-idea-validator.md) | 开发前先做竞争度扫描，用 reality_signal 决定继续或转向。 |
+| [HF Papers 研究发现流水线](../usecases/research/21-hf-papers-research-discovery.md) | 每天自动抓 Hugging Face Papers 热门论文，再联动 arXiv 深读，形成一套持续研究雷达。 |
+| [arXiv 论文阅读助手](../usecases/research/22-arxiv-paper-reader.md) | 直接按 arXiv ID 抓摘要、目录和全文，让 OpenClaw 变成可对话的论文阅读器。 |
 
 ## 金融与交易 (1)
 
@@ -105,18 +111,8 @@
 | [多源新闻摘要](../usecases/everyday/59-news-digest-aggregator.md) | 多源汇总零重复 |
 | [购物比价助手](../usecases/everyday/67-price-comparison-shopper.md) | 多平台找最优价格 |
 | [会议纪要生成](../usecases/everyday/68-meeting-notes-generator.md) | 粘贴原始笔记获取结构化纪要 |
-| [车价谈判自动化（多经销商协商）](../usecases/everyday/03-car-price-negotiation.md) | 并行沟通多家经销商并统一比较报价与条件。 |
 | [冷关系复活](../usecases/everyday/54-cold-relationship-revival.md) | 重新联系失去联系的朋友 |
 | [旅行行程规划](../usecases/everyday/70-travel-itinerary-planner.md) | 一条消息生成完整行程 |
-| [家庭餐食运营系统（Notion）](../usecases/everyday/08-family-meal-ops-notion.md) | 将餐食计划、采购清单与天气联动到同一家庭协作流程。 |
-| [超市代购自动化（1Password + MFA + Beeper）](../usecases/everyday/09-grocery-ordering-with-1password-mfa.md) | 从采购消息到待支付订单形成完整下单链路。 |
-| [血检报告结构化入库（Notion）](../usecases/everyday/11-bloodwork-to-notion-structured-db.md) | 自动提取血检字段并沉淀为可查询的健康数据库。 |
-| [邮件小票转零件清单（Receipt → BOM）](../usecases/everyday/12-email-receipt-to-parts-list.md) | 自动从收据邮件提取物料明细并输出标准 BOM。 |
-| [Alexa CLI 自然语言控制（含智能家居设备）](../usecases/everyday/14-alexa-cli-natural-language-control.md) | 用自然语言控制 Alexa 设备并接入自动化流程。 |
-| [航班邮件自动值机与靠窗选座](../usecases/everyday/15-email-flight-auto-checkin-window-seat.md) | 自动识别航班邮件并在确认后执行值机与选座。 |
-| [保险理赔自动提交与维修预约](../usecases/everyday/16-insurance-claim-and-repair-booking.md) | 串联理赔提交与后续维修预约，减少流程中断。 |
-| [Garmin 运动数据热力图（个人轨迹可视化）](../usecases/everyday/18-garmin-exercise-heatmap.md) | 导入运动轨迹后快速生成可筛选的交互热力图。 |
-| [习惯追踪与督促教练（Habit Tracker & Accountability Coach）](../usecases/everyday/habit-tracker-accountability-coach.md) | 主动发起每日打卡并跟踪 streak，帮助稳定养成习惯。 |
 | [每日晨间简报](../usecases/everyday/52-morning-briefing-telegram.md) | 天气+日历+新闻一条消息搞定 |
 | [每日学习日记](../usecases/everyday/57-daily-learning-journal.md) | 晚间问答追踪个人成长 |
 | [社交媒体监控](../usecases/everyday/64-social-media-monitor.md) | 跨平台追踪提及和情感 |
@@ -133,10 +129,20 @@
 | [Instagram 故事管理](../usecases/everyday/53-instagram-story-manager.md) | 自动发布故事并管理互动 |
 | [Telegram 智能家居](../usecases/everyday/62-smart-home-telegram.md) | 聊天控制灯光温度门锁 |
 | [Trello/Notion 整理](../usecases/everyday/66-trello-notion-organizer.md) | 夜间清理看板晨间状态报告 |
+| [车价谈判自动化（多经销商协商）](../usecases/everyday/03-car-price-negotiation.md) | 并行沟通多家经销商并统一比较报价与附加条件。 |
+| [家庭餐食运营系统（Notion）](../usecases/everyday/08-family-meal-ops-notion.md) | 将餐食计划、采购清单与天气联动到同一家庭协作流程。 |
+| [超市代购自动化（1Password + MFA + Beeper）](../usecases/everyday/09-grocery-ordering-with-1password-mfa.md) | 从采购消息到待支付订单形成完整下单链路。 |
+| [血检报告结构化入库（Notion）](../usecases/everyday/11-bloodwork-to-notion-structured-db.md) | 自动提取血检字段并沉淀为可查询的健康数据库。 |
+| [邮件小票转零件清单（Receipt → BOM）](../usecases/everyday/12-email-receipt-to-parts-list.md) | 自动从收据邮件提取物料明细并输出标准 BOM。 |
+| [Alexa CLI 自然语言控制（含智能家居设备）](../usecases/everyday/14-alexa-cli-natural-language-control.md) | 用自然语言控制 Alexa 设备并接入自动化流程。 |
+| [航班邮件自动值机与靠窗选座](../usecases/everyday/15-email-flight-auto-checkin-window-seat.md) | 自动识别航班邮件并在确认后执行值机与选座。 |
+| [保险理赔自动提交与维修预约](../usecases/everyday/16-insurance-claim-and-repair-booking.md) | 串联理赔提交与后续维修预约，减少流程中断。 |
+| [Garmin 运动数据热力图（个人轨迹可视化）](../usecases/everyday/18-garmin-exercise-heatmap.md) | 导入运动轨迹后快速生成可筛选的交互热力图。 |
+| [习惯追踪与督促教练（Habit Tracker & Accountability Coach）](../usecases/everyday/habit-tracker-accountability-coach.md) | 主动发起每日打卡并跟踪 streak，帮助稳定养成习惯。 |
 | [电话外呼提醒（Phone Call Notifications）](../usecases/everyday/phone-call-notifications.md) | 在真正重要的时候由 OpenClaw 主动给你打电话，减少关键通知遗漏。 |
 | [家庭 PM 周报](../usecases/everyday/family-pm-weekly-roundup.md) | 收集家庭话题、补做研究，并在固定时间发送一份集中周报。 |
 
-## 内容转换 (14)
+## 内容转换 (15)
 
 | 用例 | 能干什么 |
 |---|---|
@@ -151,9 +157,10 @@
 | [邮件转播客技能](../usecases/content/38-email-to-podcast-skill.md) | 邮件音频转换的可重用技能 |
 | [云端内容创作工作流](../usecases/content/cloud-content-creation-flow.md) | 把选题、写作、发布串成全自动内容生产线。 |
 | [自动化内容创作流水线](../usecases/content/auto-content-creation-pipeline.md) | 从资料收集到成稿发布的一体化内容自动化。 |
-| [播客生产流水线（Podcast Production Pipeline）](../usecases/content/podcast-production-pipeline.md) | 从调研、提纲到 show notes 和宣发文案一次产出。 |
 | [LinkedIn 周更草稿助手](../usecases/content/linkedin-drafter-showcase.md) | 按你的口吻自动生成周更内容草稿，减少写作启动成本。 |
+| [播客生产流水线（Podcast Production Pipeline）](../usecases/content/podcast-production-pipeline.md) | 从调研、提纲到 show notes 和宣发文案一次产出。 |
 | [阅读材料重打包成极简 HTML/CSS 阅读器](../usecases/content/html-css-reading-repackager.md) | 把原始资料重排成更适合阅读的轻量 HTML/CSS 页面，并支持调字号和 speed-read。 |
+| [AI 视频编辑助手](../usecases/content/48-ai-video-editing-assistant.md) | 用聊天方式完成粗剪、加字幕、转竖屏和批量导出，把重复视频后处理交给 OpenClaw。 |
 
 ## 内存管理 (11)
 
@@ -164,12 +171,12 @@
 | [每日自我改进定时任务](../usecases/memory/39-daily-self-improvement-cron.md) | 每天进步 1% |
 | [每周内存归档](../usecases/memory/41-weekly-memory-archive.md) | 将旧日志压缩为摘要 |
 | [三层内存系统](../usecases/memory/04-three-tier-memory-system.md) | 长期 + 每日 + 项目分层 |
-| [伴侣双 Bot 共享记忆层（shared-memory）](../usecases/memory/17-shared-memory-for-partner-bots.md) | 两个 OpenClaw 同步关键上下文，支持跨人协作接力。 |
 | [心跳状态监控器](../usecases/memory/36-heartbeat-state-monitor.md) | 跟踪检查新鲜度 |
 | [夜间工作 ROI 跟踪器](../usecases/memory/48-night-work-roi-tracker.md) | 跟踪自主工作的有效性 |
 | [云端智能备忘录管理](../usecases/memory/cloud-smart-memo-manager.md) | 把碎片想法自动沉淀成可检索备忘录。 |
 | [早间摘要生成器](../usecases/memory/45-morning-digest-generator.md) | 编译夜间活动 |
 | [知识图谱重建器](../usecases/memory/40-knowledge-graph-rebuilder.md) | 夜间图重建 |
+| [伴侣双 Bot 共享记忆层（shared-memory）](../usecases/memory/17-shared-memory-for-partner-bots.md) | 两个 OpenClaw 同步关键上下文，支持跨人协作接力。 |
 
 ## 夜间自动化 (15)
 
@@ -198,7 +205,6 @@
 | [安全 CTF 课程](../usecases/data/43-security-ctf-curriculum.md) | 培训挑战准备 |
 | [客户信号扫描器](../usecases/data/23-customer-signal-scanner.md) | 从频道提取反馈 |
 | [链上钱包监控器](../usecases/data/22-chain-wallet-monitor.md) | 链上变动警报 |
-| [大规模 X 数据研究管线（4M 帖文）](../usecases/data/05-large-scale-x-research-pipeline.md) | 在大样本社媒数据中提炼主题信号，支撑研究与选题决策。 |
 | [全自动信息收集系统](../usecases/data/full-auto-info-collector.md) | 从多来源持续收集信息并自动归类。 |
 | [日志异常检测](../usecases/data/19-log-anomaly-detection.md) | 统计错误检测 |
 | [数据分析工作流（Skills组合）](../usecases/data/skills-combo-data-analysis-flow.md) | 通过多个技能协同完成数据处理和输出。 |
@@ -211,13 +217,13 @@
 | [Pump.fun 扫描器](../usecases/data/24-pump-fun-scanner.md) | 新代币检测 |
 | [RSS 新闻聚合器](../usecases/data/20-rss-news-aggregator.md) | 多源新闻去重 |
 | [X 个人资料抓取器](../usecases/data/08-x-profile-scraper.md) | 社交媒体数据收集 |
+| [大规模 X 数据研究管线（4M 帖文）](../usecases/data/05-large-scale-x-research-pipeline.md) | 在大样本社媒数据中提炼主题信号，支撑研究与选题决策。 |
 
 ## 安全监控 (16)
 
 | 用例 | 能干什么 |
 |---|---|
 | [安全快速启动模板](../usecases/security/security-quickstart-guardrails.md) | 快速建立基础安全策略，适合新手的第一套防护。 |
-| [Agent 隔离身份启动（独立账号边界）](../usecases/security/01-agent-isolated-identity-bootstrap.md) | 先建立专用账号边界，再开放执行权限，降低主账号风险。 |
 | [分布式追踪基准测试](../usecases/security/28-distributed-tracing-benchmark.md) | 可观察性开销测试 |
 | [技能供应链审计](../usecases/security/31-skill-supply-chain-audit.md) | YARA 扫描恶意技能 |
 | [技能预检检查器](../usecases/security/34-skill-preflight-checker.md) | 安装前安全检查 |
@@ -232,15 +238,18 @@
 | [AWS 凭证扫描器](../usecases/security/29-aws-credential-scanner.md) | 查找暴露的 AWS 密钥 |
 | [Git 历史清理器](../usecases/security/33-git-history-cleaner.md) | 从历史中删除机密 |
 | [SSH 密钥扫描器](../usecases/security/09-ssh-key-scanner.md) | 查找暴露的 SSH 密钥 |
+| [Agent 隔离身份启动（独立账号边界）](../usecases/security/01-agent-isolated-identity-bootstrap.md) | 先建立专用账号边界，再开放执行权限，降低主账号风险。 |
 
-## 工具开发 (7)
+## 工具开发 (8)
 
 | 用例 | 能干什么 |
 |---|---|
 | [多渠道存在同步](../usecases/tools/50-multi-channel-presence-sync.md) | 统一的跨平台身份 |
 | [个人 CLI 工具包](../usecases/tools/10-personal-cli-toolkit.md) | 代理使用的自定义命令 |
-| [OpenClaw macOS 菜单栏控制台](../usecases/tools/13-macos-menubar-openclaw-console.md) | 在桌面菜单栏查看网关状态、日志并执行快捷控制。 |
 | [技能构建提示词工厂](../usecases/tools/skill-builder-prompt-workflow.md) | 用标准提示词批量生成可维护技能，减少重复劳动。 |
 | [可公开配置基线模板](../usecases/tools/sanitized-config-baseline.md) | 通过脱敏配置建立团队基线，方便复制和协作。 |
+| [OpenClaw macOS 菜单栏控制台](../usecases/tools/13-macos-menubar-openclaw-console.md) | 在桌面菜单栏查看网关状态、日志并执行快捷控制。 |
 | [AionUi 桌面协作与远程救援（OpenClaw Cowork）](../usecases/tools/aionui-cowork-desktop-remote-rescue.md) | 用可视化 Cowork 界面远程使用和修复 OpenClaw，适合离开电脑后的协作与救援。 |
 | [语音模型发现、安装并接入对话](../usecases/tools/voice-model-discovery-install-and-conversation.md) | 发现新 voice model 后，让 OpenClaw 负责检查、安装并完成对话验证。 |
+| [OpenClaw 调度 Claude Code 与 Codex CLI](../usecases/tools/51-openclaw-claude-code-codex-cli.md) | 让 OpenClaw 作为总控，把 Claude Code、Codex CLI 这类 coding harness 接进同一套工作流。 |
+

--- a/usecases/content/48-ai-video-editing-assistant.md
+++ b/usecases/content/48-ai-video-editing-assistant.md
@@ -1,0 +1,101 @@
+# AI 视频编辑助手
+
+> 用聊天方式完成粗剪、加字幕、转竖屏和批量导出，把重复视频后处理交给 OpenClaw。
+
+## 这个案例能帮你做什么
+
+- 直接用自然语言描述剪辑需求，不必每次都进时间线软件手动拖拽。
+- 自动加字幕、裁掉不需要的片段、补背景音乐，并输出适合短视频平台的成片。
+- 对多个素材批量执行同一种处理流程，节省重复劳动。
+
+## 你需要的 Skills（按类型）
+
+| 类型 | Skill / 工具 | 用途 | 来源 |
+|---|---|---|---|
+| 外部 | [`video-editor-ai`](https://clawhub.ai/skills/video-editor-ai) | 聊天式视频编辑、加 BGM、导出成片 | ClawHub |
+| 外部 | [`ai-subtitle-generator`](https://clawhub.ai/skills/ai-subtitle-generator) | 自动字幕、烧录字幕、导出 SRT | ClawHub |
+
+## 快速体验版（先跑一轮）
+
+```text
+你是我的视频后期助理。
+请先帮我预演一个最小剪辑任务：
+1. 把这段视频裁到 0:15 到 1:30
+2. 加一段偏轻快的背景音乐
+3. 自动生成英文字幕并烧录到视频里
+4. 导出为 mp4
+```
+
+## 稳定自动版（可长期运行）
+
+### 1) 安装所需技能
+
+```bash
+clawhub install video-editor-ai
+clawhub install ai-subtitle-generator
+```
+
+### 2) 单视频处理提示词
+
+```text
+Trim this video from 0:15 to 1:30, add background music (something upbeat),
+and burn subtitles in English.
+```
+
+### 3) 批量处理提示词
+
+```text
+I have 5 clips in /videos/raw/. For each one:
+- Crop to 9:16 vertical
+- Add auto-generated captions at the bottom
+- Export as mp4
+```
+
+### 4) OpenClaw 执行提示词（自动版）
+
+```text
+你是我的视频编辑助手，请执行「AI 视频编辑助手」流程。
+请使用 Skills：video-editor-ai、ai-subtitle-generator。
+
+执行步骤：
+1. 先确认输入文件路径和输出格式
+2. 按我的自然语言要求做剪辑、裁切和字幕处理
+3. 如果我要批量处理，就对整个目录执行同一套规则
+4. 输出最终文件路径，并说明做了哪些改动
+```
+
+### 5) 输出模板（可选）
+
+```markdown
+# 视频处理结果
+
+- 输入文件：
+- 输出文件：
+- 裁切范围：
+- 是否加字幕：
+- 是否加背景音乐：
+- 输出比例：
+```
+
+## 成功标准
+
+- [ ] 能通过自然语言完成一次完整视频后处理。
+- [ ] 字幕、裁切和导出设置能按要求落地。
+- [ ] 批量处理时，多份素材能复用同一套规则。
+
+## 风险与边界
+
+- 原始场景明确提醒不要把含有人脸、证件、保密屏幕的敏感素材随意上传给第三方处理服务。
+- 字幕效果和颜色风格更适合用“结果描述”表达，例如“偏暖”“适合 Shorts”，而不是过度依赖技术参数。
+- 时间戳和输出分辨率最好说清楚，否则批量处理时容易出现结果不一致。
+
+## 使用建议
+
+- 先从“剪一条视频”开始，再升级到“目录批量处理”。
+- 字幕任务里尽量说明原始语言，尤其是非英语素材。
+- 如果你做短视频分发，可以把“转 9:16 + 烧字幕 + 导出 mp4”固定成一条常用模版。
+
+## 引用来源
+
+- 来源仓库： [hesamsheikh/awesome-openclaw-usecases](https://github.com/hesamsheikh/awesome-openclaw-usecases)
+- 原始条目： [usecases/ai-video-editing.md](https://github.com/hesamsheikh/awesome-openclaw-usecases/blob/main/usecases/ai-video-editing.md)

--- a/usecases/devops/21-claworc-multi-instance-control-plane.md
+++ b/usecases/devops/21-claworc-multi-instance-control-plane.md
@@ -1,0 +1,98 @@
+# Claworc 多实例控制台
+
+> 用一个 Web 控制台集中管理多个 OpenClaw 实例，把实例隔离、权限控制和运维入口统一起来。
+
+## 这个案例能帮你做什么
+
+- 给团队里不同人、不同任务、不同模型准备独立 OpenClaw 实例。
+- 通过单一入口统一管理浏览器、终端、文件、日志和 API key。
+- 在不直接暴露每个 OpenClaw 实例的前提下，做更稳的权限控制和运维监控。
+
+## 你需要的 Skills（按类型）
+
+| 类型 | Skill / 工具 | 用途 | 来源 |
+|---|---|---|---|
+| 外部（需安装） | [`claworc`](https://github.com/gluk-w/claworc) | 多实例控制平面与管理界面 | gluk-w |
+| 外部（系统） | Docker Compose 或 Helm | 部署 Claworc 控制台 | Docker / Kubernetes |
+| 内置 | OpenClaw Gateway | 作为被管理的 Agent 实例运行入口 | OpenClaw |
+
+## 快速体验版（先跑一轮）
+
+```text
+你是我的 OpenClaw 平台架构师。
+请先帮我设计一个最小可用的 Claworc 方案：
+1. 一个实例给日常助理
+2. 一个实例给数据分析
+3. 一个实例给 IT 支持
+4. 说明每个实例为什么要独立，以及控制台应该统一看哪些信息
+本轮先不要进入生产部署细节。
+```
+
+## 稳定自动版（可长期运行）
+
+### 1) Docker Compose 方式启动
+
+```bash
+git clone https://github.com/gluk-w/claworc.git
+cd claworc
+mkdir -p ~/.claworc/data/configs
+CLAWORC_DATA_DIR=~/.claworc/data docker compose up -d
+```
+
+启动后，Dashboard 默认在：
+
+```text
+http://localhost:8000
+```
+
+### 2) 常用运维命令
+
+```bash
+docker compose logs -f
+docker compose down
+docker compose up -d
+docker compose down -v
+```
+
+### 3) 如果你要用安装脚本
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/gluk-w/claworc/main/install.sh | bash
+```
+
+### 4) OpenClaw 执行提示词（自动版）
+
+```text
+你是我的 OpenClaw 基础设施管理员。
+请按 Claworc 的方式管理多个实例：
+1. 给每个团队成员或任务类型分配独立实例
+2. 每个实例都要有独立浏览器、终端和持久化存储
+3. 控制台统一展示实例状态、日志、连接健康和访问权限
+4. 如果我要新增实例，先给出用途、模型、权限和是否需要单独 API key
+```
+
+## 成功标准
+
+- [ ] 可以从一个控制台看到多个 OpenClaw 实例。
+- [ ] 每个实例都具备独立浏览器、终端和持久化存储。
+- [ ] 默认通过控制平面代理访问，而不是把每个 Agent 端口直接暴露出去。
+
+## 风险与边界
+
+- 这更适合“团队多实例管理”而不是单机个人使用；如果你只有一个实例，复杂度可能过高。
+- Claworc 强调 SSH 隧道、代理和角色控制，部署时需要同时考虑控制平面和实例侧的网络边界。
+- 如果你希望不同实例共享同一套 API key 或模型策略，需要自己设计更细的权限边界。
+
+## 使用建议
+
+- 先用 2-3 个实例做试点，不要一上来就把所有角色都塞进去。
+- 最适合放进去的实例通常是：日常助理、数据分析、IT/运维支持。
+- 如果你已经在用多 Agent、多 Gateway，这篇可以看作进一步升级成“多实例控制平面”。
+
+## 引用来源
+
+- 来源仓库： [gluk-w/claworc](https://github.com/gluk-w/claworc)
+- 原始条目：
+  - [README.md](https://github.com/gluk-w/claworc/blob/main/README.md)
+  - [docs/install.md](https://github.com/gluk-w/claworc/blob/main/docs/install.md)
+  - [digitalknk/openclaw-runbook/showcases/claworc.md](https://github.com/digitalknk/openclaw-runbook/blob/main/showcases/claworc.md)

--- a/usecases/productivity/11-multi-gateway-feishu-bots.md
+++ b/usecases/productivity/11-multi-gateway-feishu-bots.md
@@ -1,0 +1,173 @@
+# 一个 OpenClaw 管多个飞书机器人
+
+> 用多账号、多 Agent、可选多 Gateway 的方式，把不同飞书机器人稳定路由到不同 OpenClaw 身份。
+
+## 这个案例能帮你做什么
+
+- 把主助理、编码助理、研究助理拆成不同飞书机器人，避免上下文串台。
+- 在一个 Gateway 内做多账号路由，或在同一台机器上跑多个 Gateway 做更强隔离。
+- 让不同飞书机器人各自绑定独立 workspace、agentDir 和 session store，长期保持各自人格与记忆。
+
+## 你需要的 Skills（按类型）
+
+| 类型 | Skill / 工具 | 用途 | 来源 |
+|---|---|---|---|
+| 内置 | `openclaw agents add` | 创建独立 Agent 与 workspace | OpenClaw CLI |
+| 内置 | `bindings` / `accountId` 路由 | 把不同飞书账号绑定到不同 Agent | OpenClaw Gateway |
+| 内置 | `--profile` 多 Gateway | 在同机上跑多个相互隔离的 Gateway | OpenClaw Gateway |
+| 外部（需配置） | 飞书机器人应用 | 为每个 Agent 提供独立聊天入口 | 飞书开放平台 |
+
+## 快速体验版（先跑一轮）
+
+```text
+你是我的 OpenClaw 架构助手。
+请先帮我设计一个最小可用的双机器人方案：
+1. 一个飞书机器人负责日常助理
+2. 一个飞书机器人负责编码任务
+3. 两个机器人各自绑定不同 Agent
+4. 说明是单 Gateway 多账号更适合，还是双 Gateway 更适合
+本轮先不要生成全量生产配置，只输出最小落地方案。
+```
+
+## 稳定自动版（可长期运行）
+
+### 1) 先准备两个隔离 Agent
+
+```bash
+openclaw agents add main
+openclaw agents add coding
+openclaw agents list --bindings
+```
+
+如果你需要更强隔离，可以按 profile 分开运行 Gateway：
+
+```bash
+# main
+openclaw --profile main setup
+openclaw --profile main gateway --port 18789
+
+# coding
+openclaw --profile coding setup
+openclaw --profile coding gateway --port 19001
+```
+
+```bash
+openclaw --profile main gateway install
+openclaw --profile coding gateway install
+```
+
+### 2) 在飞书侧创建多个机器人账号
+
+- 为主助理和编码助理分别创建飞书应用。
+- 每个应用都拿到各自的 `App ID` 和 `App Secret`。
+- 如果只是单 Gateway 多账号，分别把两个账号加到同一个 `channels.feishu.accounts` 下。
+
+### 3) OpenClaw 路由配置（核心）
+
+```json5
+{
+  session: {
+    dmScope: "per-account-channel-peer"
+  },
+  agents: {
+    list: [
+      {
+        id: "main",
+        workspace: "~/.openclaw/workspace-main",
+        default: true
+      },
+      {
+        id: "coding",
+        workspace: "~/.openclaw/workspace-coding"
+      }
+    ]
+  },
+  bindings: [
+    {
+      agentId: "main",
+      match: { channel: "feishu", accountId: "default" }
+    },
+    {
+      agentId: "coding",
+      match: { channel: "feishu", accountId: "coding" }
+    }
+  ],
+  channels: {
+    feishu: {
+      enabled: true,
+      defaultAccount: "default",
+      dmPolicy: "pairing",
+      accounts: {
+        default: {
+          appId: "cli_main_xxx",
+          appSecret: "main_secret"
+        },
+        coding: {
+          appId: "cli_coding_xxx",
+          appSecret: "coding_secret"
+        }
+      }
+    }
+  }
+}
+```
+
+关键点：
+
+- `bindings[].match.accountId` 决定哪个飞书账号的消息路由到哪个 Agent。
+- `defaultAccount` 让未显式指定账号的出站动作有稳定默认值。
+- `session.dmScope = "per-account-channel-peer"` 能避免同一个人分别给两个飞书机器人发消息时共用同一条 DM 会话。
+
+### 4) 启动、配对与验证
+
+```bash
+openclaw channels add
+openclaw gateway restart
+openclaw channels status --probe
+openclaw agents list --bindings
+```
+
+在两个飞书机器人里分别发一条测试消息，收到 pairing code 后批准：
+
+```bash
+openclaw pairing approve feishu <PAIRING_CODE>
+```
+
+### 5) OpenClaw 执行提示词（自动版）
+
+```text
+你是我的 OpenClaw 多机器人运维助手。
+请维护下面这套飞书多账号路由：
+1. default 账号只服务 main Agent
+2. coding 账号只服务 coding Agent
+3. 所有 direct message 都用 per-account-channel-peer 做隔离
+4. 如果我新增第三个飞书机器人，请先给出 accountId、agentId、workspace、binding 的最小补丁
+5. 每次改动前先说明会影响哪个账号和哪个 Agent
+```
+
+## 成功标准
+
+- [ ] 不同飞书机器人之间不会串会话。
+- [ ] 每个机器人都能稳定进入自己绑定的 Agent。
+- [ ] 新增账号时只需要补 `accounts` 和 `bindings`，不必重做整套配置。
+
+## 风险与边界
+
+- 多 Gateway 只有在你确实需要更强隔离或救援机器人时才值得上，官方文档默认仍建议优先用单 Gateway。
+- 如果多个实例复用了相同 `OPENCLAW_STATE_DIR`、`OPENCLAW_CONFIG_PATH` 或端口，容易出现配置冲突和会话碰撞。
+- 如果 `bindings` 省略 `accountId`，默认只会匹配默认账号。
+
+## 使用建议
+
+- 先用“单 Gateway + 多飞书账号”跑通，再决定是否升级到“多 Gateway + 多账号”。
+- 给每个 Agent 单独准备 `SOUL.md`、`USER.md`、`IDENTITY.md`，这样多机器人分工才会稳定。
+- 把主助理、编码助理、研究助理拆开时，优先按“长期人格/长期记忆”来拆，不要只按一次性任务拆。
+
+## 引用来源
+
+- 来源仓库： [openclaw/openclaw](https://github.com/openclaw/openclaw)
+- 原始条目：
+  - [docs/channels/feishu.md](https://github.com/openclaw/openclaw/blob/main/docs/channels/feishu.md)
+  - [docs/concepts/multi-agent.md](https://github.com/openclaw/openclaw/blob/main/docs/concepts/multi-agent.md)
+  - [docs/gateway/multiple-gateways.md](https://github.com/openclaw/openclaw/blob/main/docs/gateway/multiple-gateways.md)
+  - [docs/gateway/configuration-reference.md](https://github.com/openclaw/openclaw/blob/main/docs/gateway/configuration-reference.md)

--- a/usecases/productivity/12-denchclaw-local-crm-framework.md
+++ b/usecases/productivity/12-denchclaw-local-crm-framework.md
@@ -1,0 +1,103 @@
+# 本地 CRM / DenchClaw 框架
+
+> 用 DenchClaw 把 OpenClaw 变成一套本地优先的 CRM、销售自动化和业务运营工作台。
+
+## 这个案例能帮你做什么
+
+- 一条命令拉起本地 CRM，不再自己拼数据库、前端和浏览器自动化。
+- 用自然语言管理线索、客户、跟进状态和看板视图。
+- 把浏览器、数据表、文件系统和 OpenClaw agent 连成一个业务闭环。
+
+## 你需要的 Skills（按类型）
+
+| 类型 | Skill / 工具 | 用途 | 来源 |
+|---|---|---|---|
+| 外部（需安装） | [`denchclaw`](https://github.com/DenchHQ/DenchClaw) | 本地 CRM / 业务运营框架 | DenchHQ |
+| 内置 | OpenClaw profile `dench` | 独立运行 DenchClaw 对应的 OpenClaw 配置 | DenchClaw |
+| 外部（框架内置） | CRM / App Builder / Browser Automation | 管表、建应用、接浏览器 | DenchClaw 内置能力 |
+
+## 快速体验版（先跑一轮）
+
+```text
+你是我的 CRM 助手。
+请先按 DenchClaw 的思路帮我设计一个最小 Leads 管理流程：
+1. 字段包括 Name、Email、Company、Status、Notes
+2. 给出 New / Contacted / Qualified / Won / Lost 五个状态
+3. 说明适合表格视图还是 Kanban 视图
+4. 本轮先不要连接外部数据源，只输出结构和使用方法
+```
+
+## 稳定自动版（可长期运行）
+
+### 1) 一键安装
+
+```bash
+npx denchclaw@latest
+```
+
+安装完成后会在本地打开 `localhost:3100`，并创建专用 OpenClaw profile `dench`。
+
+### 2) 常用命令
+
+```bash
+npx denchclaw@latest
+npx denchclaw@latest update
+npx denchclaw restart
+npx denchclaw start
+npx denchclaw stop
+```
+
+```bash
+openclaw --profile dench gateway restart
+openclaw --profile dench config set gateway.port 19001
+openclaw --profile dench gateway install --force --port 19001
+```
+
+### 3) 初始操作提示词
+
+```text
+Hey, create a "Leads" object with fields: Name, Email, Company, Status (New/Contacted/Qualified/Won/Lost), and Notes. Import this CSV of leads I downloaded from Apollo.
+```
+
+```text
+Show me all leads where Status is "Contacted" and sort by last updated. Switch to Kanban view grouped by Status.
+```
+
+```text
+Draft a personalized outreach email to each lead in "New" status based on their company's recent news. Save the drafts in a new "Outreach Drafts" document.
+```
+
+### 4) OpenClaw 执行提示词（自动版）
+
+```text
+你是我的本地 CRM 助手，请按 DenchClaw 工作方式运行：
+1. 所有客户、线索和跟进动作都优先落在本地 CRM 里
+2. 我可以用自然语言创建对象、字段、视图和筛选条件
+3. 如果要做浏览器导入或外联动作，先说明将使用哪一类已有登录态
+4. 输出每次变更涉及的对象、视图和下一步跟进建议
+```
+
+## 成功标准
+
+- [ ] 本地能跑起 DenchClaw，并打开 `localhost:3100`。
+- [ ] 至少能建立一个 Leads 对象并切换不同视图。
+- [ ] OpenClaw 能围绕客户数据执行查询、筛选和草稿生成。
+
+## 风险与边界
+
+- DenchClaw 会把业务数据和自动化能力都收拢到本地环境，更适合个人或小团队自托管，不是即开即用的 SaaS。
+- 浏览器自动化依赖你现有登录态时，要明确哪些网站和账号是允许被代理操作的。
+- 这套方案偏“框架型案例”，适合把 CRM、外联和运营工作流一起落地，不只是单一联系人管理。
+
+## 使用建议
+
+- 先从一个对象开始，例如 Leads，再慢慢扩展到公司、联系人、外联草稿。
+- 把“导入数据”“切换视图”“生成草稿”作为三条固定口令练熟，会很快感受到价值。
+- 如果你是中文用户，后续最值得做的是把对象字段、状态枚举和常用视图完全中国化。
+
+## 引用来源
+
+- 来源仓库： [DenchHQ/DenchClaw](https://github.com/DenchHQ/DenchClaw)
+- 原始条目：
+  - [README.md](https://github.com/DenchHQ/DenchClaw/blob/main/README.md)
+  - [hesamsheikh/awesome-openclaw-usecases/usecases/local-crm-framework.md](https://github.com/hesamsheikh/awesome-openclaw-usecases/blob/main/usecases/local-crm-framework.md)

--- a/usecases/research/21-hf-papers-research-discovery.md
+++ b/usecases/research/21-hf-papers-research-discovery.md
@@ -1,0 +1,104 @@
+# HuggingFace Papers 研究发现流水线
+
+> 每天自动抓 Hugging Face Papers 热门论文，再联动 arXiv 深读，形成一套持续研究雷达。
+
+## 这个案例能帮你做什么
+
+- 每天先看 Hugging Face Papers 热榜，快速知道大家在关注什么。
+- 对某篇论文继续展开：看摘要、作者、GitHub 仓库、社区评论和更完整的 arXiv 原文。
+- 把当天读过的论文沉淀成一份中文研究简报，方便团队同步和二次检索。
+
+## 你需要的 Skills（按类型）
+
+| 类型 | Skill / 工具 | 用途 | 来源 |
+|---|---|---|---|
+| 外部 | [`hf-papers`](https://github.com/hesamsheikh/awesome-openclaw-usecases/blob/main/usecases/hf-papers-research-discovery.md) | 获取 Hugging Face Papers 热榜、搜索、详情与评论 | 社区场景说明 |
+| 外部 | [`arxiv-source`](https://github.com/hesamsheikh/awesome-openclaw-usecases/blob/main/usecases/hf-papers-research-discovery.md) | 联动 arXiv 原文做深读 | 社区场景说明 |
+| 内置 | 记忆/笔记能力 | 持续记录当日看过的论文与一句话结论 | OpenClaw Built-in |
+
+## 快速体验版（先跑一轮）
+
+```text
+你是我的 AI 研究助理。
+请先做一个 Hugging Face Papers 今日热榜预演：
+1. 列出今天最热门的 5 篇论文
+2. 每篇给出标题、点赞数、GitHub 仓库（如果有）和一句中文摘要
+3. 帮我挑出最值得深读的 2 篇
+4. 本轮先不要做长期记忆写入，只输出今日榜单和推荐理由
+```
+
+## 稳定自动版（可长期运行）
+
+### 1) 安装两个技能
+
+```bash
+clawhub install hf-papers
+clawhub install arxiv-source
+```
+
+### 2) OpenClaw 执行提示词（自动版）
+
+```text
+我想长期追踪机器学习研究，请按下面工作流运行：
+
+1. 每天早上先给我看 Hugging Face Papers 热榜前 10
+   - 每篇输出：标题、点赞数、GitHub 仓库（如果有）、一句中文总结
+
+2. 当我说“搜索 [topic]”时：
+   - 在 HF Papers 里搜索相关论文
+   - 优先标出高点赞或带 GitHub 仓库的条目
+
+3. 当我选中某篇论文时：
+   - 输出完整摘要、作者和相关资源
+   - 如果有评论，提炼社区讨论焦点
+   - 问我是否继续深读
+
+4. 如果我要深读：
+   - 用 arxiv-source 取回全文
+   - 总结核心贡献、方法、实验结果和我应该看的代码仓库
+
+5. 帮我维护一份“今日已读论文清单”，每篇保留一句 takeaway。
+```
+
+### 3) 输出模板（可选）
+
+```markdown
+# 今日 HF Papers 研究简报
+
+## 热门论文
+- 标题：
+  - 点赞：
+  - GitHub：
+  - 一句话摘要：
+
+## 深读候选
+- 论文：
+  - 为什么值得读：
+
+## 今日已读
+- 论文：
+  - takeaway：
+```
+
+## 成功标准
+
+- [ ] 能稳定拿到当日 Hugging Face Papers 热榜。
+- [ ] 选中论文后能继续拉出详情、评论和 arXiv 原文。
+- [ ] 最终能沉淀成一份当天可复用的研究简报。
+
+## 风险与边界
+
+- 这个流水线依赖公开数据源，榜单和评论区内容会随时间变化。
+- 社区热度不等于论文质量，仍然需要你自己做筛选判断。
+- 如果当天热门论文没有 arXiv 源或源信息不完整，深读环节会受限。
+
+## 使用建议
+
+- 适合每天固定一个时间跑，把“追热点”和“深读”拆成两步。
+- 给不同研究方向设置不同检索口令，例如“搜索 agentic coding”“搜索 multimodal”。
+- 如果你已经有飞书/邮件渠道，可以把最终研究简报推送出去，而不是只停留在聊天窗口里。
+
+## 引用来源
+
+- 来源仓库： [hesamsheikh/awesome-openclaw-usecases](https://github.com/hesamsheikh/awesome-openclaw-usecases)
+- 原始条目： [usecases/hf-papers-research-discovery.md](https://github.com/hesamsheikh/awesome-openclaw-usecases/blob/main/usecases/hf-papers-research-discovery.md)

--- a/usecases/research/22-arxiv-paper-reader.md
+++ b/usecases/research/22-arxiv-paper-reader.md
@@ -1,0 +1,99 @@
+# arXiv 论文阅读助手
+
+> 直接按 arXiv ID 抓摘要、目录和全文，让 OpenClaw 变成可对话的论文阅读器。
+
+## 这个案例能帮你做什么
+
+- 不再手动下载 PDF 再到处切窗口，直接在 OpenClaw 里读论文。
+- 先看摘要、再看目录、最后按需深读某一节，减少无效阅读。
+- 一次比较多篇论文，快速决定先读哪篇、哪篇只做归档。
+
+## 你需要的 Skills（按类型）
+
+| 类型 | Skill / 工具 | 用途 | 来源 |
+|---|---|---|---|
+| 外部 | [`arxiv-reader`](https://github.com/Prismer-AI/Prismer/tree/main/skills/arxiv-reader) | 获取 arXiv 摘要、目录与扁平化全文 | Prismer |
+| 内置 | 记忆/笔记能力 | 记录已读论文与一句话结论 | OpenClaw Built-in |
+
+## 快速体验版（先跑一轮）
+
+```text
+你是我的论文阅读助手。
+请先按下面方式帮我预演：
+1. 当我给出 arXiv ID 时，先只抓摘要
+2. 如果这篇值得读，再列出目录
+3. 最后用中文总结这篇论文的核心贡献
+4. 本轮只做一篇，不做批量对比
+```
+
+## 稳定自动版（可长期运行）
+
+### 1) 安装方式
+
+原始用例建议直接把 `skills/arxiv-reader/` 放进 OpenClaw 的 skills 目录中使用。
+
+### 2) OpenClaw 执行提示词（自动版）
+
+```text
+我正在做论文研究，请按这个阅读流程工作：
+
+1. 当我给你一个 arXiv ID（例如 2301.00001）：
+   - 先获取 abstract，帮我判断值不值得继续读
+   - 如果我说“继续”，再获取全文，默认去掉 appendix
+   - 最后总结核心贡献、方法和实验结果
+
+2. 当我给你多个 arXiv ID：
+   - 先取回全部摘要
+   - 给我一个对比表，说明各自更适合解决什么问题
+
+3. 当我问某个章节：
+   - 先告诉我这篇论文有哪些 sections
+   - 再抓指定章节并详细解释
+
+4. 帮我维护一份已读论文清单，每篇保留一句 takeaway。
+```
+
+### 3) 示例参数（来自原技能）
+
+全文抓取：
+
+```json
+{ "arxiv_id": "2301.00001", "remove_appendix": true }
+```
+
+目录提取：
+
+```json
+{ "arxiv_id": "2301.00001" }
+```
+
+摘要提取：
+
+```json
+{ "arxiv_id": "2301.00001" }
+```
+
+## 成功标准
+
+- [ ] 能按 arXiv ID 拉到摘要、目录和全文。
+- [ ] 多篇论文可以先做摘要级对比，再决定深读顺序。
+- [ ] 已读论文能沉淀成可回看的研究清单。
+
+## 风险与边界
+
+- 首次抓取大论文时可能要等 10-30 秒，重复请求才会更快。
+- 这类工具更适合 LaTeX 源可用的论文；如果源有缺失，解析效果会受影响。
+- 摘要和全文都是研究辅助，不能替代你自己对实验和结论的判断。
+
+## 使用建议
+
+- 先用 `arxiv_abstract` 做初筛，再决定要不要走全文。
+- 对比多篇论文时，最好给一个明确研究主题，否则相关性排序会偏散。
+- 和 HF Papers 那篇组合使用效果最好：先追热点，再深读。
+
+## 引用来源
+
+- 来源仓库： [Prismer-AI/Prismer](https://github.com/Prismer-AI/Prismer)
+- 原始条目：
+  - [skills/arxiv-reader/SKILL.md](https://github.com/Prismer-AI/Prismer/blob/main/skills/arxiv-reader/SKILL.md)
+  - [hesamsheikh/awesome-openclaw-usecases/usecases/arxiv-paper-reader.md](https://github.com/hesamsheikh/awesome-openclaw-usecases/blob/main/usecases/arxiv-paper-reader.md)

--- a/usecases/social/07-x-twitter-automation-ops.md
+++ b/usecases/social/07-x-twitter-automation-ops.md
@@ -1,0 +1,120 @@
+# X / Twitter 自动化运营
+
+> 用 OpenClaw 统一完成发帖、回复、监控、抽奖和数据抽取，把 X/Twitter 运营动作收回到聊天里。
+
+## 这个案例能帮你做什么
+
+- 直接从聊天里发帖、回复、转推、关注、私信和搜索。
+- 跑 giveaway、抽取互动用户、监控目标账号的新动态。
+- 用一个插件覆盖内容运营、社媒监听和活动执行，不必在多个面板之间切换。
+
+## 你需要的 Skills（按类型）
+
+| 类型 | Skill / 工具 | 用途 | 来源 |
+|---|---|---|---|
+| 外部（需安装） | [`@xquik/tweetclaw`](https://www.npmjs.com/package/@xquik/tweetclaw) | X/Twitter 全量运营与 API 调用 | npm |
+| 内置 | `openclaw plugins install` | 安装 TweetClaw 插件 | OpenClaw CLI |
+| 内置 | `/xstatus` / `/xtrends` | 查看账号状态与趋势 | TweetClaw 命令 |
+
+## 快速体验版（先跑一轮）
+
+```text
+你是我的 X 运营助手。
+请先做一个不直接发帖的预演：
+1. 根据我的产品定位起草 3 条推文
+2. 给出每条推文适合配什么图片或链接
+3. 设计一个“监控 3 个竞品账号”的关键词方案
+4. 本轮不要真实发帖、不要点赞、不要发私信
+```
+
+## 稳定自动版（可长期运行）
+
+### 1) 安装插件
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+### 2) 配置方式（二选一）
+
+API Key 模式：
+
+```bash
+openclaw config set plugins.entries.tweetclaw.config.apiKey 'xq_YOUR_KEY'
+```
+
+MPP 按次付费模式：
+
+```bash
+npm i mppx viem
+openclaw config set plugins.entries.tweetclaw.config.tempoPrivateKey '0xYOUR_TEMPO_KEY'
+```
+
+可选轮询：
+
+```bash
+openclaw config set plugins.entries.tweetclaw.config.pollingEnabled true
+openclaw config set plugins.entries.tweetclaw.config.pollingInterval 60
+```
+
+### 3) 常见操作提示词
+
+发帖：
+
+```text
+Post a tweet: "Just shipped a new feature — try it out!"
+```
+
+抽奖：
+
+```text
+Pick 3 random winners from the retweeters of this tweet: https://x.com/username/status/123456789. Exclude accounts with fewer than 50 followers.
+```
+
+导出互动用户：
+
+```text
+Extract all users who liked this tweet and export as CSV: https://x.com/username/status/123456789
+```
+
+监控账号：
+
+```text
+Monitor @elonmusk and notify me whenever he posts a new tweet.
+```
+
+### 4) OpenClaw 执行提示词（自动版）
+
+```text
+你是我的 X/Twitter 运营助手。
+请使用 TweetClaw 完成下面这些事情：
+1. 起草和发布内容前先给我确认
+2. 日常监控我关心的账号、关键词和趋势
+3. 如果我要做活动，支持抽奖和导出互动名单
+4. 输出每一步调用的目标动作，并在失败时给出回退建议
+```
+
+## 成功标准
+
+- [ ] 能完成发帖、监控、抽奖或数据导出中的至少一类核心动作。
+- [ ] 账号状态和趋势命令能正常返回结果。
+- [ ] 自动监控开启后，可以把新动态回传到聊天窗口。
+
+## 风险与边界
+
+- TweetClaw 覆盖大量 API 能力，但不同能力的付费层级和访问范围不同。
+- 涉及发帖、私信、关注等写操作时，必须先设定你的审核边界，避免误触发。
+- 高频自动化可能触发平台风控，建议先从监控、草稿和只读分析开始。
+
+## 使用建议
+
+- 先把它当“运营控制台”，再逐步开放真实写操作。
+- giveaway、抽奖和导出名单这类动作最适合先写成固定口令模板。
+- 如果你做内容增长，把 `/xtrends` 和账号监控结合起来，会比单纯定时发帖更有价值。
+
+## 引用来源
+
+- 来源仓库： [Xquik-dev/tweetclaw](https://github.com/Xquik-dev/tweetclaw)
+- 原始条目：
+  - [README.md](https://github.com/Xquik-dev/tweetclaw/blob/main/README.md)
+  - [hesamsheikh/awesome-openclaw-usecases/usecases/x-twitter-automation.md](https://github.com/hesamsheikh/awesome-openclaw-usecases/blob/main/usecases/x-twitter-automation.md)

--- a/usecases/tools/51-openclaw-claude-code-codex-cli.md
+++ b/usecases/tools/51-openclaw-claude-code-codex-cli.md
@@ -1,0 +1,168 @@
+# OpenClaw 调度 Claude Code 与 Codex
+
+> 让 OpenClaw 作为总控，把 Claude Code、Codex CLI 这类 coding harness 接进同一套工作流。
+
+## 这个案例能帮你做什么
+
+- 在聊天里直接把编码任务路由给 Claude Code 或 Codex CLI。
+- 用 CLI backend 做文本级兜底，用 ACP session 做持续会话式编码。
+- 让不同 Agent 固定使用不同 coding runtime，避免所有代码任务都挤在一个执行器里。
+
+## 你需要的 Skills（按类型）
+
+| 类型 | Skill / 工具 | 用途 | 来源 |
+|---|---|---|---|
+| 内置 | CLI Backends | 把 `claude-cli/...`、`codex-cli/...` 接成 OpenClaw 模型后端 | OpenClaw Gateway |
+| 内置 | ACP Agents | 让外部 coding harness 以持久会话方式运行 | OpenClaw Built-in |
+| 外部（需安装） | `claude` CLI | 复杂多文件编码任务 | Claude Code CLI |
+| 外部（需安装） | `codex` CLI | 常规实现、修复和代码解释 | Codex CLI |
+
+## 快速体验版（先跑一轮）
+
+```text
+你是我的编码任务调度器。
+请根据任务复杂度在 Claude Code 和 Codex CLI 之间选一个执行器，并说明原因：
+1. 如果任务跨 3 个以上文件，优先 Claude Code
+2. 如果任务是单点修复或明确功能实现，优先 Codex CLI
+3. 输出推荐执行器、原因、预估改动范围、失败时回退策略
+
+任务：修复一个 README 中的拼写错误，并顺手检查相关示例命令是否一致。
+```
+
+## 稳定自动版（可长期运行）
+
+### 1) 先确认两个 CLI 后端可用
+
+官方文档里最小验证命令是：
+
+```bash
+openclaw agent --message "hi" --model claude-cli/opus-4.6
+openclaw agent --message "hi" --model codex-cli/gpt-5.4
+```
+
+### 2) CLI backend 配置（文本兜底）
+
+```json5
+{
+  agents: {
+    defaults: {
+      cliBackends: {
+        "claude-cli": {
+          command: "/opt/homebrew/bin/claude"
+        },
+        "codex-cli": {
+          command: "/opt/homebrew/bin/codex"
+        }
+      },
+      model: {
+        primary: "anthropic/claude-opus-4-6",
+        fallbacks: [
+          "claude-cli/opus-4.6",
+          "codex-cli/gpt-5.4"
+        ]
+      },
+      models: {
+        "anthropic/claude-opus-4-6": { alias: "Opus" },
+        "claude-cli/opus-4.6": {},
+        "codex-cli/gpt-5.4": {}
+      }
+    }
+  }
+}
+```
+
+这一层适合“API provider 挂了也要有文本结果”的兜底模式。
+
+### 3) ACP 持久会话配置（持续编码）
+
+```json5
+{
+  agents: {
+    list: [
+      {
+        id: "codex",
+        runtime: {
+          type: "acp",
+          acp: {
+            agent: "codex",
+            backend: "acpx",
+            mode: "persistent",
+            cwd: "/workspace/repo-a"
+          }
+        }
+      },
+      {
+        id: "claude",
+        runtime: {
+          type: "acp",
+          acp: {
+            agent: "claude",
+            backend: "acpx",
+            mode: "persistent",
+            cwd: "/workspace/repo-a"
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+### 4) 典型操作命令
+
+从聊天线程里拉起持久 Codex session：
+
+```text
+/acp spawn codex --mode persistent --thread auto
+```
+
+检查 ACP runtime 状态：
+
+```text
+/acp status
+```
+
+如果你希望 ACP client 直接连到 OpenClaw session：
+
+```bash
+acpx openclaw exec "Summarize the active OpenClaw session state."
+acpx openclaw sessions ensure --name codex-bridge
+```
+
+### 5) OpenClaw 执行提示词（自动版）
+
+```text
+你是我的编码任务分发器。
+请按下面规则使用 Claude Code 或 Codex CLI：
+1. 多文件重构、架构决策、复杂上下文优先交给 Claude Code
+2. 明确范围的功能实现、修复、代码解释优先交给 Codex CLI
+3. 先判断是否需要 ACP 持久会话；需要多轮跟进时使用 ACP
+4. 如果只是兜底文本响应，允许走 cliBackends fallback
+5. 每次输出：选择的执行器、原因、预估文件数、是否需要持续线程
+```
+
+## 成功标准
+
+- [ ] OpenClaw 能正确识别何时该用 Codex、何时该用 Claude Code。
+- [ ] API provider 不可用时，CLI backend 仍能给出稳定文本结果。
+- [ ] 需要多轮跟进的编码任务能固定在同一个 ACP 线程里继续执行。
+
+## 风险与边界
+
+- CLI backend 是文本兜底模式，官方文档明确说明这一路径下 OpenClaw tools 不可用。
+- CLI backend 不支持流式输出；响应是收集完再返回。
+- Codex CLI 的 resume 输出目前比初次 `--json` 运行更不结构化，长会话调试时要有心理预期。
+
+## 使用建议
+
+- 先把 CLI backend 当“保险丝”，再把 ACP 当“真正的持续编码线程”。
+- 如果 gateway 跑在 launchd/systemd 下，优先给 `claude`、`codex` 配绝对路径，避免 PATH 问题。
+- 给编码专用 Agent 单独 workspace，比在主助理里临时切后端更稳。
+
+## 引用来源
+
+- 来源仓库： [openclaw/openclaw](https://github.com/openclaw/openclaw)
+- 原始条目：
+  - [docs/gateway/cli-backends.md](https://github.com/openclaw/openclaw/blob/main/docs/gateway/cli-backends.md)
+  - [docs/tools/acp-agents.md](https://github.com/openclaw/openclaw/blob/main/docs/tools/acp-agents.md)
+  - [docs/cli/acp.md](https://github.com/openclaw/openclaw/blob/main/docs/cli/acp.md)


### PR DESCRIPTION
## Summary
- add 8 new OpenClaw use cases across productivity, research, content, social, tools, and devops
- prefer official docs and primary source repos over secondary tutorial sources
- update use case index JSON/Markdown and refresh README counts from 176 to 184

## Verification
- verified new files follow the existing use case template sections
- verified README and index counts match the JSON index
- no automated tests run (documentation-only change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档**
  * 更新了使用场景总数统计（176 → 184），各分类数量随之调整
  * 新增 8 个使用场景文档：飞书多机器人路由、Claworc 多实例控制台、本地 CRM 框架、HuggingFace 论文研究流水线、arXiv 论文阅读助手、AI 视频编辑助手、X/Twitter 自动化运营、Claude Code 与 Codex CLI 调度
  * 完整更新了使用场景索引和分类导航

<!-- end of auto-generated comment: release notes by coderabbit.ai -->