### PR TITLE
docs: add 8 OpenClaw use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 - 部署与配置：Mac、Windows、Linux VPS、多 Agent
 - 渠道接入：飞书、钉钉、企业微信、QQ（持续补充）
-- 使用场景：184 个真实案例与工作流
+- 使用场景：192 个真实案例与工作流
 
 ## 开始使用 OpenClaw
 
@@ -21,7 +21,7 @@
 
 1. [部署后 5 分钟快速体验](./quickstart/00-5min-quickstart.md)
 2. [7 天上手路径](./quickstart/01-7day-path.md)
-3. [按分类找案例（184个）](./resources/usecases-index.md)
+3. [按分类找案例（192个）](./resources/usecases-index.md)
 
 ### 推荐部署入口
 
@@ -34,7 +34,7 @@
 
 - [飞书接入对话（基础篇）](./channels/02-feishu-basic.md)
 - [企业微信接入对话](./channels/01-wecom-intelligent-bot.md)
-- 钉钉接入对话（待补）
+- [钉钉 AI 助手](./usecases/productivity/13-dingtalk-ai-assistant.md)
 
 ## 你可以先从这 10 个案例开始尝试
 
@@ -51,15 +51,15 @@
 
 ## 分类导航
 
-- [全量用例索引（184）](./resources/usecases-index.md)
-- [社交媒体（7）](./usecases/social)
-- [创意与构建（8）](./usecases/creative)
-- [基础设施与 DevOps（12）](./usecases/devops)
-- [生产力（30）](./usecases/productivity)
-- [研究与学习（12）](./usecases/research)
-- [金融与交易（1）](./usecases/finance)
+- [全量用例索引（192）](./resources/usecases-index.md)
+- [社交媒体（8）](./usecases/social)
+- [创意与构建（9）](./usecases/creative)
+- [基础设施与 DevOps（13）](./usecases/devops)
+- [生产力（32）](./usecases/productivity)
+- [研究与学习（13）](./usecases/research)
+- [金融与交易（2）](./usecases/finance)
 - [日常生活（33）](./usecases/everyday)
-- [内容转换（15）](./usecases/content)
+- [内容转换（16）](./usecases/content)
 - [内存管理（11）](./usecases/memory)
 - [夜间自动化（15）](./usecases/automation)
 - [数据分析（16）](./usecases/data)

--- a/channels/README.md
+++ b/channels/README.md
@@ -11,6 +11,7 @@
 
 - 飞书：看 [飞书接入对话（基础篇）](./02-feishu-basic.md)
 - 企业微信：看 [企业微信智能机器人接入](./01-wecom-intelligent-bot.md)
+- 钉钉：看 [钉钉 AI 助手](../usecases/productivity/13-dingtalk-ai-assistant.md)
 
 ## 目录约定
 
@@ -30,7 +31,6 @@
 
 - 飞书高级篇：多机器人、多账号、多 Agent 绑定
 - 飞书高级篇：会话隔离、`dmScope`、routing / binding
-- 钉钉接入
 - QQ 接入
 
 ## 说明

--- a/resources/usecases-index.json
+++ b/resources/usecases-index.json
@@ -1654,5 +1654,77 @@
     "sourceRepo": "gluk-w/claworc",
     "sourcePath": "README.md",
     "sourceUrl": "https://github.com/gluk-w/claworc/blob/main/README.md"
+  },
+  {
+    "title": "小红书内容自动化",
+    "desc": "辅助完成小红书选题、文案、封面和排期发布。",
+    "category": "社交媒体",
+    "localPath": "usecases/social/08-xiaohongshu-content-automation.md",
+    "sourceRepo": "AlexAnys/awesome-openclaw-usecases-zh",
+    "sourcePath": "usecases/cn-xiaohongshu-automation.md",
+    "sourceUrl": "https://github.com/AlexAnys/awesome-openclaw-usecases-zh/blob/main/usecases/cn-xiaohongshu-automation.md"
+  },
+  {
+    "title": "AI YouTube 视频剪辑（Tubeify）",
+    "desc": "用 Tubeify API 自动删除视频里的停顿和口头禅。",
+    "category": "创意与构建",
+    "localPath": "usecases/creative/ai-youtube-video-editing-tubeify.md",
+    "sourceRepo": "cogine-ai/awesome-openclaw-zh",
+    "sourcePath": "pull/7",
+    "sourceUrl": "https://github.com/cogine-ai/awesome-openclaw-zh/pull/7"
+  },
+  {
+    "title": "加密货币自动注册域名（LobsterDomains）",
+    "desc": "通过 API 完成域名查询、链上付款确认和注册流程。",
+    "category": "基础设施与 DevOps",
+    "localPath": "usecases/devops/autonomous-domain-registration-lobsterdomains.md",
+    "sourceRepo": "cogine-ai/awesome-openclaw-zh",
+    "sourcePath": "pull/7",
+    "sourceUrl": "https://github.com/cogine-ai/awesome-openclaw-zh/pull/7"
+  },
+  {
+    "title": "钉钉 AI 助手",
+    "desc": "把 OpenClaw 接进钉钉，让团队在原有办公群里触发 AI 任务。",
+    "category": "生产力",
+    "localPath": "usecases/productivity/13-dingtalk-ai-assistant.md",
+    "sourceRepo": "AlexAnys/awesome-openclaw-usecases-zh",
+    "sourcePath": "usecases/cn-dingtalk-ai-assistant.md",
+    "sourceUrl": "https://github.com/AlexAnys/awesome-openclaw-usecases-zh/blob/main/usecases/cn-dingtalk-ai-assistant.md"
+  },
+  {
+    "title": "电商多 Agent 运营助手",
+    "desc": "用多个 Agent 分别处理销售、库存、客服和商品分析。",
+    "category": "生产力",
+    "localPath": "usecases/productivity/14-ecommerce-multi-agent-ops.md",
+    "sourceRepo": "AlexAnys/awesome-openclaw-usecases-zh",
+    "sourcePath": "usecases/cn-ecommerce-multi-agent.md",
+    "sourceUrl": "https://github.com/AlexAnys/awesome-openclaw-usecases-zh/blob/main/usecases/cn-ecommerce-multi-agent.md"
+  },
+  {
+    "title": "Suppr 文献检索与文档翻译",
+    "desc": "用 Suppr MCP 或 Skills 接入学术文献检索、论文元数据整理和 PDF 翻译。",
+    "category": "研究与学习",
+    "localPath": "usecases/research/23-suppr-literature-translation.md",
+    "sourceRepo": "zjg678/suppr-mcp",
+    "sourcePath": "README.md",
+    "sourceUrl": "https://github.com/zjg678/suppr-mcp/blob/main/README.md"
+  },
+  {
+    "title": "A 股每日行情监控",
+    "desc": "自动整理 A 股行情、板块轮动和自选股变化。",
+    "category": "金融与交易",
+    "localPath": "usecases/finance/02-a-share-market-monitor.md",
+    "sourceRepo": "AlexAnys/awesome-openclaw-usecases-zh",
+    "sourcePath": "usecases/cn-a-share-monitor.md",
+    "sourceUrl": "https://github.com/AlexAnys/awesome-openclaw-usecases-zh/blob/main/usecases/cn-a-share-monitor.md"
+  },
+  {
+    "title": "微信公众号自动发布",
+    "desc": "串起选题、写稿、排版和公众号草稿箱推送。",
+    "category": "内容转换",
+    "localPath": "usecases/content/49-wechat-mp-automation.md",
+    "sourceRepo": "AlexAnys/awesome-openclaw-usecases-zh",
+    "sourcePath": "usecases/cn-wechat-mp-automation.md",
+    "sourceUrl": "https://github.com/AlexAnys/awesome-openclaw-usecases-zh/blob/main/usecases/cn-wechat-mp-automation.md"
   }
 ]

--- a/resources/usecases-index.md
+++ b/resources/usecases-index.md
@@ -1,10 +1,10 @@
 # 用例总览
 
-当前共收录 **184** 个中文可用案例。
+当前共收录 **192** 个中文可用案例。
 
 按分类浏览：
 
-## 社交媒体 (7)
+## 社交媒体 (8)
 
 | 用例 | 能干什么 |
 |---|---|
@@ -15,8 +15,9 @@
 | [每周技术发现精选](../usecases/social/tech-discoveries-showcase.md) | 自动追踪和筛选技术动态，输出可读性高的周报。 |
 | [X 账号分析](../usecases/social/x-account-analysis.md) | 获取你的 X 账号的定性分析。 |
 | [X / Twitter 自动化运营](../usecases/social/07-x-twitter-automation-ops.md) | 用 OpenClaw 统一完成发帖、回复、监控、抽奖和数据抽取，把 X/Twitter 运营动作收回到聊天里。 |
+| [小红书内容自动化](../usecases/social/08-xiaohongshu-content-automation.md) | 辅助完成小红书选题、文案、封面和排期发布。 |
 
-## 创意与构建 (8)
+## 创意与构建 (9)
 
 | 用例 | 能干什么 |
 |---|---|
@@ -28,8 +29,9 @@
 | [YouTube 内容流水线](../usecases/creative/youtube-content-pipeline.md) | 为 YouTube 频道自动化视频创意发掘、研究和追踪。 |
 | [Excalidraw Diagram-as-Code（流程图自动生成）](../usecases/creative/02-excalidraw-diagram-as-code.md) | 让 OpenClaw 直接生成 Excalidraw JSON，把文本需求快速转成流程图。 |
 | [WhatsApp 驱动 UI 生成与截图回传](../usecases/creative/whatsapp-driven-ui-with-screenshot-feedback.md) | 通过 WhatsApp 远程生成界面并回传截图，先看效果再继续迭代。 |
+| [AI YouTube 视频剪辑（Tubeify）](../usecases/creative/ai-youtube-video-editing-tubeify.md) | 用 Tubeify API 自动删除视频里的停顿和口头禅。 |
 
-## 基础设施与 DevOps (12)
+## 基础设施与 DevOps (13)
 
 | 用例 | 能干什么 |
 |---|---|
@@ -45,8 +47,9 @@
 | [Telegram 驱动 iOS 提交与 TestFlight 更新](../usecases/devops/19-telegram-driven-ios-testflight-release.md) | 在聊天中触发 iOS 发布流程并标准化 TestFlight 更新。 |
 | [自主教育游戏开发流水线（Autonomous Educational Game Development Pipeline）](../usecases/devops/autonomous-game-dev-pipeline.md) | 以先修 Bug 再做新游戏的规则持续推进教育游戏开发。 |
 | [Claworc 多实例控制台](../usecases/devops/21-claworc-multi-instance-control-plane.md) | 用一个 Web 控制台集中管理多个 OpenClaw 实例，把实例隔离、权限控制和运维入口统一起来。 |
+| [加密货币自动注册域名（LobsterDomains）](../usecases/devops/autonomous-domain-registration-lobsterdomains.md) | 通过 API 完成域名查询、链上付款确认和注册流程。 |
 
-## 生产力 (30)
+## 生产力 (32)
 
 | 用例 | 能干什么 |
 |---|---|
@@ -80,8 +83,10 @@
 | [任务时间块排程与周复盘助理](../usecases/productivity/task-timeblocking-and-weekly-review-assistant.md) | 按优先级排进日历，并基于会议转录输出 weekly review 和后续动作。 |
 | [一个 OpenClaw 管多个飞书机器人](../usecases/productivity/11-multi-gateway-feishu-bots.md) | 用多账号、多 Agent、可选多 Gateway 的方式，把不同飞书机器人稳定路由到不同 OpenClaw 身份。 |
 | [本地 CRM / DenchClaw 框架](../usecases/productivity/12-denchclaw-local-crm-framework.md) | 用 DenchClaw 把 OpenClaw 变成一套本地优先的 CRM、销售自动化和业务运营工作台。 |
+| [钉钉 AI 助手](../usecases/productivity/13-dingtalk-ai-assistant.md) | 把 OpenClaw 接进钉钉，让团队在原有办公群里触发 AI 任务。 |
+| [电商多 Agent 运营助手](../usecases/productivity/14-ecommerce-multi-agent-ops.md) | 用多个 Agent 分别处理销售、库存、客服和商品分析。 |
 
-## 研究与学习 (12)
+## 研究与学习 (13)
 
 | 用例 | 能干什么 |
 |---|---|
@@ -97,12 +102,14 @@
 | [开工前想法验证闸门（Pre-Build Idea Validator）](../usecases/research/pre-build-idea-validator.md) | 开发前先做竞争度扫描，用 reality_signal 决定继续或转向。 |
 | [HF Papers 研究发现流水线](../usecases/research/21-hf-papers-research-discovery.md) | 每天自动抓 Hugging Face Papers 热门论文，再联动 arXiv 深读，形成一套持续研究雷达。 |
 | [arXiv 论文阅读助手](../usecases/research/22-arxiv-paper-reader.md) | 直接按 arXiv ID 抓摘要、目录和全文，让 OpenClaw 变成可对话的论文阅读器。 |
+| [Suppr 文献检索与文档翻译](../usecases/research/23-suppr-literature-translation.md) | 用 Suppr MCP 或 Skills 接入学术文献检索、论文元数据整理和 PDF 翻译。 |
 
-## 金融与交易 (1)
+## 金融与交易 (2)
 
 | 用例 | 能干什么 |
 |---|---|
 | [Polymarket 自动驾驶](../usecases/finance/polymarket-autopilot.md) | 在预测市场上进行自动化模拟交易，带有回测、策略分析和每日绩效报告。 |
+| [A 股每日行情监控](../usecases/finance/02-a-share-market-monitor.md) | 自动整理 A 股行情、板块轮动和自选股变化。 |
 
 ## 日常生活 (33)
 
@@ -142,7 +149,7 @@
 | [电话外呼提醒（Phone Call Notifications）](../usecases/everyday/phone-call-notifications.md) | 在真正重要的时候由 OpenClaw 主动给你打电话，减少关键通知遗漏。 |
 | [家庭 PM 周报](../usecases/everyday/family-pm-weekly-roundup.md) | 收集家庭话题、补做研究，并在固定时间发送一份集中周报。 |
 
-## 内容转换 (15)
+## 内容转换 (16)
 
 | 用例 | 能干什么 |
 |---|---|
@@ -161,6 +168,7 @@
 | [播客生产流水线（Podcast Production Pipeline）](../usecases/content/podcast-production-pipeline.md) | 从调研、提纲到 show notes 和宣发文案一次产出。 |
 | [阅读材料重打包成极简 HTML/CSS 阅读器](../usecases/content/html-css-reading-repackager.md) | 把原始资料重排成更适合阅读的轻量 HTML/CSS 页面，并支持调字号和 speed-read。 |
 | [AI 视频编辑助手](../usecases/content/48-ai-video-editing-assistant.md) | 用聊天方式完成粗剪、加字幕、转竖屏和批量导出，把重复视频后处理交给 OpenClaw。 |
+| [微信公众号自动发布](../usecases/content/49-wechat-mp-automation.md) | 串起选题、写稿、排版和公众号草稿箱推送。 |
 
 ## 内存管理 (11)
 
@@ -252,4 +260,3 @@
 | [AionUi 桌面协作与远程救援（OpenClaw Cowork）](../usecases/tools/aionui-cowork-desktop-remote-rescue.md) | 用可视化 Cowork 界面远程使用和修复 OpenClaw，适合离开电脑后的协作与救援。 |
 | [语音模型发现、安装并接入对话](../usecases/tools/voice-model-discovery-install-and-conversation.md) | 发现新 voice model 后，让 OpenClaw 负责检查、安装并完成对话验证。 |
 | [OpenClaw 调度 Claude Code 与 Codex CLI](../usecases/tools/51-openclaw-claude-code-codex-cli.md) | 让 OpenClaw 作为总控，把 Claude Code、Codex CLI 这类 coding harness 接进同一套工作流。 |
-

--- a/usecases/content/49-wechat-mp-automation.md
+++ b/usecases/content/49-wechat-mp-automation.md
@@ -1,0 +1,81 @@
+# 微信公众号自动发布
+
+> 用 OpenClaw 串起选题、写稿、排版和草稿箱推送，减少公众号运营的重复劳动。
+
+## 这个案例能帮你做什么
+
+- 从热点、资料或旧文章中生成公众号选题和长文初稿。
+- 将 Markdown 转成公众号编辑器友好的排版，并上传封面图和正文图片。
+- 把文章推送到公众号草稿箱，让人工只负责最终审核和发布。
+
+## 你需要的 Skills（按类型）
+
+| 类型 | Skill / 工具 | 用途 | 来源 |
+|---|---|---|---|
+| 外部 | [`md2wechat-skill`](https://github.com/geekjourneyx/md2wechat-skill) | Markdown 转公众号排版并推送草稿箱 | 社区项目 |
+| 外部（可选） | [`wechat-publisher`](https://github.com/0731coderlee-sudo/wechat-publisher) | 一键将 Markdown 推送到公众号草稿箱 | 社区项目 |
+| 外部（可选） | [`china-hot-ranks`](https://github.com/lucianaib0318/china-hot-ranks) | 聚合微博、抖音、B 站等热点 | 社区项目 |
+
+## 快速体验版（先跑一轮）
+
+```text
+你是我的公众号运营助手。
+请把下面这篇 Markdown 转成适合微信公众号阅读的版本：
+1. 保留一级标题和小标题层级
+2. 自动生成 2 个备选标题和 1 段摘要
+3. 只输出排版后的内容，不要发布
+
+[粘贴 Markdown]
+```
+
+## 稳定自动版（可长期运行）
+
+### 1) 准备微信公众号凭证
+
+在微信公众平台获取：
+
+- AppID
+- AppSecret
+- IP 白名单配置权限
+
+个人订阅号通常可以写入草稿箱，但最终发布往往仍需人工在后台或公众号助手 App 里确认。
+
+### 2) 安装排版与发布工具
+
+```bash
+brew install geekjourneyx/tap/md2wechat
+md2wechat config init
+```
+
+如果使用 Skill 方式，也可以按对应项目说明安装 `wechat-publisher`。
+
+### 3) OpenClaw 执行提示词（自动版）
+
+```text
+你是我的公众号内容运营助手，请执行「公众号草稿生产」流程。
+
+执行步骤：
+1. 根据今天的热点和我的账号定位，给出 3 个选题
+2. 让我确认选题后，写一篇 1500-2500 字公众号长文
+3. 生成标题、摘要、封面图建议和正文图片建议
+4. 转换为公众号友好的 Markdown 排版
+5. 推送到草稿箱；如果当前账号不能 API 发布，只返回草稿信息并提醒人工审核
+```
+
+## 成功标准
+
+- [ ] 能从 Markdown 生成适合公众号的排版内容。
+- [ ] 能成功创建公众号草稿或输出可复制到编辑器的版本。
+- [ ] 发布前保留人工审核环节。
+
+## 风险与边界
+
+- AppSecret 泄露等同于账号被接管，必须通过环境变量或本地配置管理。
+- AI 生成内容需要人工检查事实、版权和合规风险。
+- 个人订阅号和未认证账号的发布接口权限可能受限，不要假设可以全自动群发。
+
+## 引用来源
+
+- 来源仓库： [AlexAnys/awesome-openclaw-usecases-zh](https://github.com/AlexAnys/awesome-openclaw-usecases-zh)
+- 原始条目： [usecases/cn-wechat-mp-automation.md](https://github.com/AlexAnys/awesome-openclaw-usecases-zh/blob/main/usecases/cn-wechat-mp-automation.md)
+- 相关项目： [geekjourneyx/md2wechat-skill](https://github.com/geekjourneyx/md2wechat-skill)

--- a/usecases/creative/ai-youtube-video-editing-tubeify.md
+++ b/usecases/creative/ai-youtube-video-editing-tubeify.md
@@ -1,0 +1,76 @@
+# AI YouTube 视频剪辑（Tubeify）
+
+> 用 Tubeify API 自动删除视频里的停顿和口头禅，让 OpenClaw 接管重复剪辑动作。
+
+## 这个案例能帮你做什么
+
+- 把原始视频 URL 交给 OpenClaw，由 Tubeify 自动剪掉长停顿和口头禅。
+- 不打开剪辑软件，也能完成一次短视频粗剪和导出。
+- 适合 YouTuber、播客剪辑、课程录屏和短视频团队先做批处理。
+
+## 你需要的 Skills（按类型）
+
+| 类型 | Skill / 工具 | 用途 | 来源 |
+|---|---|---|---|
+| 外部 | [`tubeify`](https://clawhub.ai/esokullu/tubeify) | AI 视频剪辑 API，处理停顿、语速和字幕等参数 | ClawHub |
+| 外部 | Tubeify API | 提交视频处理任务并轮询结果 | Tubeify |
+
+## 快速体验版（先跑一轮）
+
+```text
+你是我的视频剪辑助手。
+请先为这个视频生成 Tubeify 处理计划：
+视频 URL：[视频 URL]
+目标：
+1. 删除超过 0.5 秒的停顿
+2. 保持原始语速
+3. 不改变视频比例
+4. 本轮只输出请求参数，不要提交任务或付款
+```
+
+## 稳定自动版（可长期运行）
+
+### 1) OpenClaw 执行提示词（自动版）
+
+```text
+你是我的视频剪辑助手，请使用 Tubeify 处理以下视频：
+
+视频 URL：[URL]
+处理要求：
+1. 删除长停顿
+2. 保持 1.0x 语速
+3. 如需字幕，先确认语言和字幕样式
+4. 任务提交前展示费用、参数和风险
+5. 任务完成后返回下载链接和处理摘要
+```
+
+### 2) 输出模板
+
+```markdown
+# Tubeify 处理结果
+
+- 输入视频：
+- 处理参数：
+- 任务 ID：
+- 状态：
+- 下载链接：
+- 注意事项：
+```
+
+## 成功标准
+
+- [ ] 能生成明确的 Tubeify 请求参数。
+- [ ] 真实提交前会确认费用和视频 URL。
+- [ ] 完成后能返回下载链接或任务状态。
+
+## 风险与边界
+
+- 涉及付费处理，提交任务和付款前必须请求用户确认。
+- 不要上传包含人脸、证件、客户资料、会议录屏等敏感素材。
+- 视频长度、格式和费用限制以 Tubeify 当前 API 文档为准。
+
+## 引用来源
+
+- 来源 PR： [cogine-ai/awesome-openclaw-zh#7](https://github.com/cogine-ai/awesome-openclaw-zh/pull/7)
+- 官网： [tubeify.xyz](https://tubeify.xyz)
+- Skill 文档： [tubeify.xyz/skills.md](https://tubeify.xyz/skills.md)

--- a/usecases/devops/autonomous-domain-registration-lobsterdomains.md
+++ b/usecases/devops/autonomous-domain-registration-lobsterdomains.md
@@ -1,0 +1,67 @@
+# 加密货币自动注册域名（LobsterDomains）
+
+> 让 OpenClaw 通过 API 完成域名查询、链上付款确认和注册流程。
+
+## 这个案例能帮你做什么
+
+- 查询目标域名是否可注册，以及当前价格和可用后缀。
+- 用 USDC、USDT、ETH、BTC 等方式完成付款确认后继续注册。
+- 获得 DNS 管理凭据，把域名购买流程纳入自动化项目启动链路。
+
+## 你需要的 Skills（按类型）
+
+| 类型 | Skill / 工具 | 用途 | 来源 |
+|---|---|---|---|
+| 外部 | [`lobsterdomains`](https://clawhub.ai/esokullu/lobsterdomains) | 域名查询、注册和链上付款确认 | ClawHub |
+| 外部 | LobsterDomains API Key | 调用域名注册 API | LobsterDomains |
+
+## 快速体验版（先跑一轮）
+
+```text
+你是我的域名助手。
+请帮我查询下面 5 个域名是否可注册，并按价格排序：
+1. [domain-a].com
+2. [domain-b].xyz
+3. [domain-c].ai
+4. [domain-d].org
+5. [domain-e].dev
+本轮只查询，不注册、不付款。
+```
+
+## 稳定自动版（可长期运行）
+
+### 1) 获取 API Key
+
+在 LobsterDomains 控制台生成 API Key，并通过环境变量或本地安全配置传给 OpenClaw。
+
+### 2) OpenClaw 执行提示词（自动版）
+
+```text
+你是我的域名注册助手，请使用 LobsterDomains 完成以下流程：
+
+目标域名：[域名]
+执行步骤：
+1. 查询域名可用性和价格
+2. 展示价格、币种、链、收款地址和到期/续费规则
+3. 等我确认后再进入付款流程
+4. 我提供交易 hash 后，再提交注册请求
+5. 返回 DNS 管理凭据，并提醒我保存到密码管理器
+```
+
+## 成功标准
+
+- [ ] 查询阶段不触发付款或注册。
+- [ ] 注册前明确展示价格、链和币种。
+- [ ] 注册成功后返回 DNS 管理入口或凭据保存建议。
+
+## 风险与边界
+
+- 域名注册和链上付款不可轻易回滚，必须显式确认。
+- API Key、DNS 凭据和交易 hash 不应写入公开仓库。
+- 建议先把域名注册流程用于测试域名，再接入正式业务域名。
+
+## 引用来源
+
+- 来源 PR： [cogine-ai/awesome-openclaw-zh#7](https://github.com/cogine-ai/awesome-openclaw-zh/pull/7)
+- 官网： [lobsterdomains.xyz](https://lobsterdomains.xyz)
+- Skill 文档： [lobsterdomains.xyz/skills.md](https://lobsterdomains.xyz/skills.md)

--- a/usecases/finance/02-a-share-market-monitor.md
+++ b/usecases/finance/02-a-share-market-monitor.md
@@ -1,0 +1,88 @@
+# A 股每日行情监控
+
+> 让 OpenClaw 在交易日前后自动整理 A 股行情、板块轮动和自选股变化。
+
+## 这个案例能帮你做什么
+
+- 开盘前整理隔夜外盘、A50、今日重要事件和自选股提醒。
+- 收盘后汇总指数涨跌、成交量、涨跌家数、板块排名和资金流向。
+- 跟踪自选股表现，把每日复盘自动推送到飞书、钉钉或企业微信。
+
+## 你需要的 Skills（按类型）
+
+| 类型 | Skill / 工具 | 用途 | 来源 |
+|---|---|---|---|
+| 外部 | [`AKShare`](https://github.com/akfamily/akshare) | 获取 A 股、港股、指数、板块和宏观数据 | 开源金融数据库 |
+| 外部（可选） | [`mcp-cn-a-stock`](https://github.com/elsejj/mcp-cn-a-stock) | 用 MCP 方式查询 A 股个股信息 | 社区 MCP |
+| 内置 | Cron / 定时任务 | 每个交易日自动推送简报 | OpenClaw |
+
+## 快速体验版（先跑一轮）
+
+```text
+你是我的 A 股信息整理助手。
+请用可获取的数据生成一份盘后复盘：
+1. 上证、深成指、创业板指数涨跌
+2. 涨幅前 5 的行业板块
+3. 北向资金或主力资金摘要
+4. 我的自选股：600519、300750、000858
+只做信息整理，不给买卖建议。
+```
+
+## 稳定自动版（可长期运行）
+
+### 1) 安装数据依赖
+
+```bash
+pip install akshare
+```
+
+如果使用 MCP 服务，则按 `mcp-cn-a-stock` 项目说明配置 MCP server。
+
+### 2) OpenClaw 执行提示词（自动版）
+
+```text
+你是我的 A 股行情监控助手，请在每个交易日执行：
+
+盘前 08:30：
+1. 整理隔夜美股、A50、重要财经日历
+2. 标出可能影响我自选股的事件
+
+盘后 15:30：
+1. 整理指数涨跌、成交量、涨跌家数
+2. 输出板块涨跌 TOP5
+3. 汇总自选股表现和异常波动
+4. 明确声明：这不是投资建议
+```
+
+### 3) 输出模板
+
+```markdown
+# A 股每日复盘
+
+- 日期：
+- 市场概览：
+- 热点板块：
+- 资金流向：
+- 自选股：
+- 明日关注：
+- 风险提示：仅供信息整理，不构成投资建议。
+```
+
+## 成功标准
+
+- [ ] 能稳定生成盘前或盘后简报。
+- [ ] 自选股代码能被正确识别。
+- [ ] 输出只做信息整理，不直接生成买卖指令。
+
+## 风险与边界
+
+- AKShare 部分接口依赖公开网站数据，海外 IP 可能访问不稳定。
+- 金融信息有延迟和缺失风险，重要决策要交叉验证。
+- 本用例不构成投资建议，不应让 AI 自动下单。
+
+## 引用来源
+
+- 来源仓库： [AlexAnys/awesome-openclaw-usecases-zh](https://github.com/AlexAnys/awesome-openclaw-usecases-zh)
+- 原始条目： [usecases/cn-a-share-monitor.md](https://github.com/AlexAnys/awesome-openclaw-usecases-zh/blob/main/usecases/cn-a-share-monitor.md)
+- 数据库： [akfamily/akshare](https://github.com/akfamily/akshare)
+- MCP： [elsejj/mcp-cn-a-stock](https://github.com/elsejj/mcp-cn-a-stock)

--- a/usecases/productivity/13-dingtalk-ai-assistant.md
+++ b/usecases/productivity/13-dingtalk-ai-assistant.md
@@ -1,0 +1,82 @@
+# 钉钉 AI 助手
+
+> 把 OpenClaw 接进钉钉，让团队在原有办公群里直接触发 AI 任务。
+
+## 这个案例能帮你做什么
+
+- 在钉钉私聊或群聊中直接与 OpenClaw 对话，不要求团队成员切换新工具。
+- 使用钉钉 Stream 模式接收消息，个人电脑或内网机器也可以先跑通。
+- 支持群聊中 @ 机器人触发，避免普通讨论被 AI 频繁打断。
+
+## 你需要的 Skills（按类型）
+
+| 类型 | Skill / 工具 | 用途 | 来源 |
+|---|---|---|---|
+| 外部 | [`@soimy/dingtalk`](https://github.com/soimy/openclaw-channel-dingtalk) | 钉钉通道插件，连接 OpenClaw 与钉钉机器人 | 社区插件 |
+| 外部 | 钉钉开放平台应用 | 获取 Client ID / Client Secret 并开启机器人能力 | 钉钉开放平台 |
+
+## 快速体验版（先跑一轮）
+
+```text
+你是我的钉钉 AI 助手。
+请在这个钉钉会话中完成一次最小测试：
+1. 用 3 条内容说明你已经收到消息
+2. 总结你可以处理的办公任务类型
+3. 不要执行任何外部写入动作
+```
+
+## 稳定自动版（可长期运行）
+
+### 1) 创建钉钉应用
+
+在钉钉开放平台创建企业内部应用，开启机器人能力，记录：
+
+- Client ID / AppKey
+- Client Secret / AppSecret
+- 消息接收模式：优先选择 Stream 模式
+
+### 2) 安装通道插件
+
+```bash
+openclaw plugins install @soimy/dingtalk
+```
+
+将插件加入 OpenClaw 插件 allowlist：
+
+```json
+{
+  "plugins": {
+    "enabled": true,
+    "allow": ["@soimy/dingtalk"]
+  }
+}
+```
+
+### 3) OpenClaw 执行提示词（自动版）
+
+```text
+你是公司钉钉 AI 助手。
+当用户在群里 @ 你时，请按下面规则处理：
+1. 先判断任务类型：信息查询、文档整理、会议纪要、待办拆解、技术排障
+2. 如果任务需要访问外部系统，先说明需要的权限和数据范围
+3. 对写入、删除、发送外部消息等动作，必须先请求确认
+4. 输出要适合钉钉群阅读：结论先行，步骤清晰
+```
+
+## 成功标准
+
+- [ ] 钉钉私聊能收到 OpenClaw 回复。
+- [ ] 群聊中只有 @ 机器人时才触发。
+- [ ] 高风险动作会先请求确认。
+
+## 风险与边界
+
+- 企业群里不要默认开放 shell、文件系统、账号后台等高权限工具。
+- 群聊上下文可能包含敏感业务信息，建议配置 allowlist 和 pairing。
+- 通道插件版本会影响多媒体消息支持范围，生产使用前要先验证图片、文件、语音等类型。
+
+## 引用来源
+
+- 来源仓库： [AlexAnys/awesome-openclaw-usecases-zh](https://github.com/AlexAnys/awesome-openclaw-usecases-zh)
+- 原始条目： [usecases/cn-dingtalk-ai-assistant.md](https://github.com/AlexAnys/awesome-openclaw-usecases-zh/blob/main/usecases/cn-dingtalk-ai-assistant.md)
+- 通道插件： [soimy/openclaw-channel-dingtalk](https://github.com/soimy/openclaw-channel-dingtalk)

--- a/usecases/productivity/14-ecommerce-multi-agent-ops.md
+++ b/usecases/productivity/14-ecommerce-multi-agent-ops.md
@@ -1,0 +1,92 @@
+# 电商多 Agent 运营助手
+
+> 用多个 OpenClaw Agent 分别处理销售、库存、客服和商品分析，让电商运营从查后台变成问对话。
+
+## 这个案例能帮你做什么
+
+- 在飞书、钉钉或 Slack 群里直接查询销售、库存、商品和客户数据。
+- 用不同 Agent 绑定不同群组：销售助手看销售，客服助手看售后，库存助手看补货。
+- 通过定时任务主动推送库存预警、退货异常和每日运营简报。
+
+## 你需要的 Skills（按类型）
+
+| 类型 | Skill / 工具 | 用途 | 来源 |
+|---|---|---|---|
+| 自建 | `sales-query` | 查询销售额、订单、退货和趋势 | 电商 API |
+| 自建 | `inventory-alert` | 检查低库存、断货和补货建议 | 电商 API |
+| 自建 | `customer-insight` | 汇总新客、复购、地域和客诉信号 | 电商 API |
+| 内置 | 多 Agent / bindings | 将不同群聊路由到不同 Agent | OpenClaw |
+
+## 快速体验版（先跑一轮）
+
+```text
+你是我的电商运营助手。
+请先用模拟数据生成一份今日运营简报：
+1. 今日销售额、订单数、客单价
+2. 库存低于安全线的商品
+3. 退款率异常的商品
+4. 明天优先处理的 3 件事
+本轮不要连接真实店铺后台。
+```
+
+## 稳定自动版（可长期运行）
+
+### 1) 按角色拆分 Agent
+
+```json
+{
+  "agents": {
+    "list": [
+      { "id": "sales", "name": "销售助手", "workspace": "/data/ws/sales" },
+      { "id": "support", "name": "售后客服", "workspace": "/data/ws/support" },
+      { "id": "inventory", "name": "库存助手", "workspace": "/data/ws/inventory" }
+    ]
+  }
+}
+```
+
+### 2) 将群组绑定到 Agent
+
+```json
+{
+  "bindings": [
+    {
+      "match": { "channel": "feishu", "peer": { "kind": "group", "id": "oc_sales" } },
+      "agentId": "sales"
+    },
+    {
+      "match": { "channel": "feishu", "peer": { "kind": "group", "id": "oc_support" } },
+      "agentId": "support"
+    }
+  ]
+}
+```
+
+### 3) OpenClaw 执行提示词（自动版）
+
+```text
+你是电商运营多 Agent 系统里的销售助手。
+请只处理销售和商品分析相关问题。
+当用户询问今日销售、热销商品、滞销商品、退款异常时：
+1. 调用对应 Skill 查询数据
+2. 先给结论，再给表格
+3. 标注异常数据和可能原因
+4. 不执行退款、改价、下架等写操作
+```
+
+## 成功标准
+
+- [ ] 不同群组消息能进入对应 Agent。
+- [ ] 销售、客服、库存能力边界清晰。
+- [ ] 写操作默认关闭，只有查数和告警自动执行。
+
+## 风险与边界
+
+- 淘宝、京东、拼多多等平台 API 通常需要商家认证和应用审核。
+- Shopify 等跨境电商平台 API 更开放，适合作为第一版验证。
+- 电商场景不要让 AI 默认执行退款、改价、下架、发券等动作。
+
+## 引用来源
+
+- 来源仓库： [AlexAnys/awesome-openclaw-usecases-zh](https://github.com/AlexAnys/awesome-openclaw-usecases-zh)
+- 原始条目： [usecases/cn-ecommerce-multi-agent.md](https://github.com/AlexAnys/awesome-openclaw-usecases-zh/blob/main/usecases/cn-ecommerce-multi-agent.md)

--- a/usecases/research/23-suppr-literature-translation.md
+++ b/usecases/research/23-suppr-literature-translation.md
@@ -1,0 +1,90 @@
+# Suppr 文献检索与文档翻译
+
+> 用 Suppr MCP 或 Skills 把学术文献检索、论文元数据整理和 PDF 翻译接入 OpenClaw。
+
+## 这个案例能帮你做什么
+
+- 用自然语言检索 PubMed 方向的学术文献，并返回标题、摘要、DOI、PMID、作者和期刊信息。
+- 创建、查询和管理文档翻译任务，支持 PDF、Word、PPT、Excel、TXT、HTML 等格式。
+- 把论文检索、筛选、翻译和阅读笔记整理成一个研究工作流。
+
+## 你需要的 Skills（按类型）
+
+| 类型 | Skill / 工具 | 用途 | 来源 |
+|---|---|---|---|
+| 外部 | [`suppr-mcp`](https://github.com/zjg678/suppr-mcp) | MCP 方式接入 Suppr 文献检索和翻译 API | 社区 MCP |
+| 外部 | [`suppr-skills`](https://github.com/WildDataX/suppr-skills) | Claude Code / Skill 方式调用 Suppr 检索和翻译能力 | 社区 Skills |
+| 外部 | `SUPPR_API_KEY` | 调用 Suppr API 的认证密钥 | Suppr |
+
+## 快速体验版（先跑一轮）
+
+```text
+你是我的学术研究助手。
+请搜索「CRISPR gene editing therapy」相关的最新论文：
+1. 返回前 5 篇
+2. 每篇给标题、年份、期刊、DOI、PMID 和 2 句摘要
+3. 最后按研究方向归类
+本轮只做检索，不翻译全文。
+```
+
+## 稳定自动版（可长期运行）
+
+### 1) 安装 MCP Server
+
+```bash
+npm install -g suppr-mcp
+export SUPPR_API_KEY="your_api_key_here"
+```
+
+也可以用 npx 方式启动：
+
+```bash
+npx suppr-mcp
+```
+
+### 2) MCP 配置示例
+
+```json
+{
+  "mcpServers": {
+    "suppr": {
+      "command": "npx",
+      "args": ["-y", "suppr-mcp"],
+      "env": {
+        "SUPPR_API_KEY": "your_api_key_here"
+      }
+    }
+  }
+}
+```
+
+### 3) OpenClaw 执行提示词（自动版）
+
+```text
+你是我的论文研究助手，请执行「Suppr 文献检索与翻译」流程。
+
+执行步骤：
+1. 根据我的研究问题检索相关论文
+2. 按相关性筛选前 10 篇，列出 DOI、PMID、摘要和年份
+3. 让我选择需要阅读全文或翻译的论文
+4. 对确认的 PDF 创建翻译任务
+5. 轮询任务状态，完成后返回译文链接和阅读笔记
+```
+
+## 成功标准
+
+- [ ] 能返回结构化文献元数据。
+- [ ] 能创建并查询翻译任务状态。
+- [ ] 输出中明确区分“检索结果”和“AI 总结/归纳”。
+
+## 风险与边界
+
+- 需要 Suppr API Key，不应把密钥写入仓库。
+- 上传或提交文档 URL 前，要确认版权、隐私和数据合规要求。
+- 文献检索结果需要人工复核，尤其是医学和药物相关结论。
+
+## 引用来源
+
+- 来源 issue： [cogine-ai/awesome-openclaw-zh#11](https://github.com/cogine-ai/awesome-openclaw-zh/issues/11)
+- MCP： [zjg678/suppr-mcp](https://github.com/zjg678/suppr-mcp)
+- Skills： [WildDataX/suppr-skills](https://github.com/WildDataX/suppr-skills)

--- a/usecases/social/08-xiaohongshu-content-automation.md
+++ b/usecases/social/08-xiaohongshu-content-automation.md
@@ -1,0 +1,76 @@
+# 小红书内容自动化
+
+> 让 OpenClaw 辅助完成小红书选题、文案、封面和排期发布。
+
+## 这个案例能帮你做什么
+
+- 根据热点和账号定位生成小红书标题、正文、标签和封面建议。
+- 用浏览器自动化流程辅助登录、排期和发布，减少重复操作。
+- 追踪笔记表现，把高赞主题和文案风格沉淀为后续创作参考。
+
+## 你需要的 Skills（按类型）
+
+| 类型 | Skill / 工具 | 用途 | 来源 |
+|---|---|---|---|
+| 外部 | [`XiaohongshuSkills`](https://github.com/white0dew/XiaohongshuSkills) | 小红书内容生成、登录与发布自动化 | 社区项目 |
+| 外部 | Chrome 浏览器 | 账号登录和页面自动化 | 本地运行环境 |
+| 外部 | Python 3.10+ | 运行自动化脚本依赖 | 本地运行环境 |
+
+## 快速体验版（先跑一轮）
+
+```text
+你是我的小红书内容助理。
+请围绕「居家收纳」生成一篇小红书图文笔记草稿：
+1. 给 5 个标题
+2. 写正文，不超过 600 字
+3. 给 8 个标签
+4. 给封面图构图建议
+本轮只生成内容，不登录、不发布。
+```
+
+## 稳定自动版（可长期运行）
+
+### 1) 安装社区技能
+
+```bash
+git clone https://github.com/white0dew/XiaohongshuSkills.git
+cd XiaohongshuSkills
+pip install -r requirements.txt
+```
+
+首次使用建议只做登录验证：
+
+```bash
+python scripts/cdp_publish.py login
+```
+
+### 2) OpenClaw 执行提示词（自动版）
+
+```text
+你是我的小红书运营助手，请执行「小红书内容自动化」流程。
+
+执行步骤：
+1. 根据账号定位和最近表现，挑 3 个选题
+2. 让我确认后生成标题、正文、标签和封面建议
+3. 如果需要发布，先确认发布时间、账号和内容最终版
+4. 通过 XiaohongshuSkills 执行发布或排期
+5. 发布后记录 URL、发布时间和后续要追踪的数据
+```
+
+## 成功标准
+
+- [ ] 能生成符合小红书语境的标题、正文和标签。
+- [ ] 自动发布前会先确认账号、内容和发布时间。
+- [ ] 发布结果能被记录，方便后续复盘。
+
+## 风险与边界
+
+- 小红书对自动化登录和发布有风控，建议先用测试账号验证。
+- 不建议批量灌水式发布，容易影响账号权重。
+- RPA 浏览器自动化不是官方 API，平台页面改版后可能需要调整脚本。
+
+## 引用来源
+
+- 来源仓库： [AlexAnys/awesome-openclaw-usecases-zh](https://github.com/AlexAnys/awesome-openclaw-usecases-zh)
+- 原始条目： [usecases/cn-xiaohongshu-automation.md](https://github.com/AlexAnys/awesome-openclaw-usecases-zh/blob/main/usecases/cn-xiaohongshu-automation.md)
+- 相关项目： [white0dew/XiaohongshuSkills](https://github.com/white0dew/XiaohongshuSkills)


### PR DESCRIPTION
## Summary
- Add 8 new source-backed OpenClaw use cases, increasing the indexed case count from 184 to 192
- Cover Chinese-growth and high-intent topics: DingTalk, WeChat Official Account, Xiaohongshu, ecommerce multi-agent ops, A-share monitoring, Suppr literature workflows, Tubeify video editing, and LobsterDomains domain registration
- Update README, channel entrypoints, Markdown index, and JSON index counts/categories

## Validation
- `jq empty resources/usecases-index.json`
- `jq 'length' resources/usecases-index.json` -> 192
- `find usecases -mindepth 2 -maxdepth 2 -type f -name '*.md' | wc -l` -> 192
- JSON localPath/missing/duplicate check -> no missing files, no duplicate paths
- Changed-file internal Markdown link check -> passed
- Stale count scan -> only existing X/Twitter status IDs contained 184 as a substring
- `git diff --check` -> passed

## Notes
- This PR updates the source content only. The opcboost.com site still needs its normal content sync/deploy after merge.